### PR TITLE
obtain JSZip via preload services

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faircopy",
-  "version": "1.1.9-dev.2",
+  "version": "1.1.9-dev.3",
   "description": "A word processor for the humanities scholar.",
   "main": "public/electron.js",
   "private": true,
@@ -27,10 +27,10 @@
   "author": "Performant Software Solutions LLC",
   "homepage": ".",
   "devDependencies": {
+    "@electron/notarize": "^2.1.0",
     "dotenv": "^8.2.0",
     "electron": "^25.5.0",
-    "electron-builder": "^24.6.3",
-    "@electron/notarize": "^2.1.0"
+    "electron-builder": "^24.6.3"
   },
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/public/main-process/WorkerWindow.js
+++ b/public/main-process/WorkerWindow.js
@@ -23,7 +23,7 @@ class WorkerWindow {
         ipcMain.on('close-worker-window', this.closeMessageHandler)
 
         this.workerWindow = new BrowserWindow({
-            show: false,
+            show: true,
             webPreferences: {
                 webSecurity: !this.debug,
                 nodeIntegration: true,

--- a/public/main-process/worker-window-preload.js
+++ b/public/main-process/worker-window-preload.js
@@ -1,5 +1,7 @@
 
 const preloadServices = require('./preload-worker-services')
+const JSZip = require('jszip');
+preloadServices.services.JSZip = JSZip
 
 window.fairCopy = {
     rootComponent: "WorkerWindow",

--- a/src/workers/project-archive-worker.js
+++ b/src/workers/project-archive-worker.js
@@ -1,9 +1,9 @@
-import JSZip from 'jszip'
 import { getAuthToken } from '../model/cloud-api/auth'
 import { checkInResources, checkOutResources } from '../model/cloud-api/resource-management'
 import { getResourceAsync, getResourcesAsync } from "../model/cloud-api/resources"
 
 const fairCopy = window.fairCopy
+const JSZip = fairCopy.services.JSZip
 
 // Worker state
 let projectArchiveState = { open: false, jobQueue: [] }


### PR DESCRIPTION
This fix addresses bugs related to saving that arose from the Electron and Webpack upgrades.