### PR TITLE
Improvements to Preview Window

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faircopy",
-  "version": "1.2.0-dev.5",
+  "version": "1.2.0-dev.6",
   "description": "A word processor for the humanities scholar.",
   "main": "public/electron.js",
   "private": true,

--- a/public/main-process/FairCopyApplication.js
+++ b/public/main-process/FairCopyApplication.js
@@ -249,7 +249,7 @@ class FairCopyApplication {
 
   async createPreviewWindow(previewData) {
     if( !this.previewView ) {
-      this.previewView = await this.createWindow('preview-window-preload.js', 800, 600, true, '#fff', false )
+      this.previewView = await this.createWindow('preview-window-preload.js', 800, 600, true, '#fff', false, true )
       this.previewView.on('close', e => delete this.previewView )
     }
     this.previewView.webContents.send('updatePreview', previewData)

--- a/public/main-process/FairCopyApplication.js
+++ b/public/main-process/FairCopyApplication.js
@@ -52,6 +52,10 @@ class FairCopyApplication {
       this.closeProject()
       this.exitApp()
     })
+
+    ipcMain.on('openWebpage', (event, url ) => {
+      shell.openExternal(url)
+    })  
     
     ipcMain.on('exitApp', (event) => { 
       if( this.projectWindow ) {

--- a/public/main-process/ProjectStore.js
+++ b/public/main-process/ProjectStore.js
@@ -172,7 +172,7 @@ class ProjectStore {
     }
     previewResource(resourceData, previewData) {
         try {
-            const teiDocXML = serializeResource(resourceData)
+            const teiDocXML = serializeResource(resourceData,false)
             const previewDataWithXML = { ...previewData, teiDocXML }
             this.fairCopyApplication.openPreview(previewDataWithXML)    
         } catch(e) {

--- a/public/main-process/serialize-xml.js
+++ b/public/main-process/serialize-xml.js
@@ -5,14 +5,15 @@ const jsdom = require("jsdom")
 const { JSDOM } = jsdom
 const serialize = require("w3c-xmlserializer");
 
-const serializeResource = function serializeResource(resourceData) {
+const serializeResource = function serializeResource(resourceData,formatXML=true) {
     const { resourceEntry, contents } = resourceData
     if( resourceEntry.type === 'teidoc') {
         const { childEntries } = resourceData
-        return serializeTEIDoc(childEntries,contents)
+        const teiDocXML = serializeTEIDoc(childEntries,contents)
+        return formatXML ? formatXMLFile(teiDocXML) : teiDocXML
     } else {
         const content = contents[resourceEntry.id]
-        return serializeXMLFile(content)
+        return formatXML ? formatXMLFile(content) : content
     }
 }
 
@@ -36,7 +37,7 @@ function serializeTEIDoc(childEntries,contents) {
     teiDoc.appendChild(header)
     resources.map( resource => teiDoc.appendChild(resource))
     const teiDocXML = serialize(xmlDoc)
-    return serializeXMLFile(teiDocXML)
+    return teiDocXML
 }
 
 function getResourceEl( resourceXML, elName, localID ) {
@@ -47,7 +48,7 @@ function getResourceEl( resourceXML, elName, localID ) {
     return el
 }
 
-function serializeXMLFile(content) {
+function formatXMLFile(content) {
     try {
         const xml = format(content, {
             indentation: '\t', 

--- a/src/components/preview-window/PreviewWindow.js
+++ b/src/components/preview-window/PreviewWindow.js
@@ -90,18 +90,8 @@ const htmlToReactParserOptions = () => {
       replace(domNode) {
         switch (domNode.name) {
             // TODO process anchor tags only (not outbound links)
-            case 'tei-graphic': {
-                const src = domNode.attribs?.url;
-                if (!src) {
-                  return domNode;
-                }
-                const desc = ""
-                return (
-                  <figure className="inline-figure">
-                    <img src={src} alt={desc || ''} className="inline-image" />
-                    { desc ? <figcaption>{desc}</figcaption> : null }
-                  </figure>
-                );
+            case 'tei-figure': {
+                return parseFigure(domNode)
             }
           default:
             /* Otherwise, Just pass through */
@@ -168,4 +158,34 @@ function domToHTML5(XML_dom){
     }
 
     return convertEl(XML_dom);
+}
+
+function parseGraphic(domNode) {
+    const src = domNode.attribs?.url;
+    let desc = ""
+    for( const child of domNode.children ) {
+        if( child.name === 'tei-desc') {
+            desc = child.children[0]?.data
+        }
+    }
+    return { src, desc }
+}
+
+function parseFigure(domNode) {
+    for( const child of domNode.children ) {
+        if( child.name === 'tei-graphic' ) {
+            const { src, desc } = parseGraphic(child)     
+            if( !src ) return domNode
+            const figureRend = domNode.attribs?.rend
+            const figureRendition = domNode.attribs?.rendition
+            return (
+                <tei-figure>
+                    <tei-graphic>
+                        <img src={src} alt={desc || ''} rend={figureRend} rendition={figureRendition} />
+                    </tei-graphic>
+                </tei-figure>
+            );              
+        }
+    }
+    return domNode
 }

--- a/src/components/preview-window/PreviewWindow.js
+++ b/src/components/preview-window/PreviewWindow.js
@@ -190,7 +190,7 @@ function parseLink( domNode, parserOptions) {
     const refRend = domNode.attribs?.rend
     const refRendition = domNode.attribs?.rendition
     const onClick = target.startsWith('#') ? onClickAnchorTag : onClickExternal
-    return <tei-ref rend={refRend} rendition={refRendition} onClick={onClick}>{domToReact(domNode.children, parserOptions)}</tei-ref>
+    return <tei-ref id={domNode.attribs.id} rend={refRend} rendition={refRendition} onClick={onClick}>{domToReact(domNode.children, parserOptions)}</tei-ref>
 }
 
 function parseFigure(domNode) {


### PR DESCRIPTION
* Improvements to the sizing and layout of images in the preview window as they respond to custom CSS.
* Links in the preview window now work, both to external websites and anchor tags within the document. Link behavior is triggered by the use of a ref element with a target attribute.
* XML used by preview window was being pretty formatted, which resulted in extra spaces in some documents.