### PR TITLE
Fix for SurfaceEditor crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faircopy",
   "productName": "FairCopy",
-  "version": "1.2.1-dev.4",
+  "version": "1.2.1-dev.5",
   "description": "A word processor for the humanities scholar.",
   "main": "./.webpack/main",
   "private": true,

--- a/src/render/components/main-window/tei-editor/attribute-fields/TEIDataPointerField.jsx
+++ b/src/render/components/main-window/tei-editor/attribute-fields/TEIDataPointerField.jsx
@@ -137,7 +137,7 @@ export default class TEIDataPointerField extends Component {
     const options = this.valuesToOptions(
       idMap.getRelativeURIList(resourceEntry.localID, parentEntry?.localID)
     );
-    const values = value.length > 0 ? value.split(" ") : [];
+    const values = value && value.length > 0 ? value.split(" ") : [];
     const selectedOptions = this.valuesToOptions(values);
     const key = `multiterm-${Date.now()}`;
 


### PR DESCRIPTION
# Summary

- Fixes an issue that would crash the surface editor if there was no `ana` attribute on a zone.