### PR TITLE
Version control updates, orphaned resources migration and prevention

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faircopy",
   "productName": "FairCopy",
-  "version": "1.2.1-dev.5",
+  "version": "1.3.0-dev.1",
   "description": "A word processor for the humanities scholar.",
   "main": "./.webpack/main",
   "private": true,

--- a/src/main-process/FairCopyApplication.js
+++ b/src/main-process/FairCopyApplication.js
@@ -125,6 +125,9 @@ class FairCopyApplication {
     ipcMain.on('updateResource', (event, resourceEntry) => { 
       this.fairCopySession.updateResource(resourceEntry) 
     })
+    ipcMain.on('startMigratingResource', (event, resourceID) => { 
+      this.sendToMainWindow('resourceMigrationStarted', resourceID)
+    })
     ipcMain.on('requestImageData', (event) => {
       const paths = this.mainMenu.openAddImage()
       if( paths ) {

--- a/src/main-process/ProjectStore.js
+++ b/src/main-process/ProjectStore.js
@@ -412,7 +412,7 @@ class ProjectStore {
                 if( parentEntry ) this.fairCopyApplication.sendToAllWindows('resourceEntryUpdated', parentEntry )   
                 this.fairCopyApplication.sendToAllWindows('resourceContentUpdated', { resourceID: resourceEntry.id, messageID: 'check-out-messsage', resourceContent: content })     
             } 
-            checkOutStatus.push({ state, resourceEntry })
+            checkOutStatus.push({ state, resourceEntry, parentEntry })
         }
         const idMap = this.fairCopyApplication.fairCopySession.idMapAuthority.checkOut(resources)
         this.projectArchiveWorker.postMessage({ messageType: 'write-file', fileID: idMapEntryName, data: idMap })

--- a/src/muiTheme.js
+++ b/src/muiTheme.js
@@ -6,6 +6,10 @@ const theme = createTheme({
       main: '#43639D',
       dark: '#283B5E',
     },
+    error: {
+      main: '#f44336',
+      dark: '#c00f0c',
+    },
     info: {
       main: '#1976d2',
       dark: '#01579B',

--- a/src/render/components/App.jsx
+++ b/src/render/components/App.jsx
@@ -11,6 +11,7 @@ import ProjectSettingsWindow from "./project-settings-window/ProjectSettingsWind
 import FairCopyProject from "../model/FairCopyProject";
 import ImageView from "../model/ImageView";
 import { getConfigStatus } from "../model/faircopy-config";
+import MigrateResourcesDialog from "./main-window/dialogs/MigrateResourcesDialog";
 
 const fairCopy = window.fairCopy;
 
@@ -26,6 +27,7 @@ export default class App extends Component {
       appConfig: null,
       checkingOut: false,
       checkOutError: null,
+      migrateResourcesActive: false,
       projectSettingsActive: false,
     };
 
@@ -137,8 +139,9 @@ export default class App extends Component {
     // breakpoints not to be honored. Only needed for debugging these paths.
     // setTimeout( () => {
     const fairCopyProject = new FairCopyProject(projectData);
+    const migrateResourcesActive = fairCopyProject.orphanedResources?.length > 0;
     this.setTitle(fairCopyProject.projectName);
-    this.setState({ ...this.state, fairCopyProject });
+    this.setState({ ...this.state, fairCopyProject, migrateResourcesActive });
     this.addToRecentProjects(fairCopyProject);
     // },2000)
   }
@@ -200,6 +203,7 @@ export default class App extends Component {
       previewView,
       appConfig,
       incompatInfo,
+      migrateResourcesActive,
       projectSettingsActive,
       checkingOut,
       checkOutError,
@@ -254,9 +258,17 @@ export default class App extends Component {
               onClose={onClose}
             ></ProjectSettingsWindow>
           )}
+          <MigrateResourcesDialog
+            fairCopyProject={fairCopyProject}
+            open={migrateResourcesActive}
+            onSuccess={() => {
+              this.setState({ ...this.state, migrateResourcesActive: false })
+              this.refreshMainWindow()
+            }}
+          ></MigrateResourcesDialog>
           <MainWindow
             appConfig={appConfig}
-            hidden={projectSettingsActive}
+            hidden={projectSettingsActive || migrateResourcesActive}
             onProjectSettings={() => {
               this.setState({ ...this.state, projectSettingsActive: true });
             }}

--- a/src/render/components/common/PopupMenu.jsx
+++ b/src/render/components/common/PopupMenu.jsx
@@ -42,7 +42,7 @@ export default class PopupMenu extends Component {
             if (menuOption.id === 'delete') {
                 menuItems.push(<StyledDivider component="li" key="divider" light />)
             }
-            const icon = this.MENU_ICONS[menuOption.id] || '';
+            const icon = Object.hasOwn(this.MENU_ICONS, menuOption.id) ? this.MENU_ICONS[menuOption.id] : ''
             menuItems.push(
                 <StyledMenuItem
                     onClick={onClick}

--- a/src/render/components/common/PopupMenu.jsx
+++ b/src/render/components/common/PopupMenu.jsx
@@ -1,7 +1,33 @@
 import React, { Component } from 'react'
-import { MenuItem, Menu } from '@material-ui/core'
+import { MenuItem, Menu, Divider, withStyles, ListItemIcon, ListItemText } from '@material-ui/core'
+
+const StyledMenuItem = withStyles((theme) => ({
+    root: {
+        '&.danger .MuiListItemIcon-root, &.danger .MuiListItemText-primary': {
+            color: theme.palette.error.dark,
+        },
+        '& .MuiListItemIcon-root': {
+            minWidth: '32px'
+        }
+    },
+}))(MenuItem)
+
+const StyledDivider = withStyles((theme) => ({
+    root: {
+        margin: '4px 0',
+    },
+}))(Divider)
 
 export default class PopupMenu extends Component {
+    MENU_ICONS = {
+        'check-in': 'fa-cloud-arrow-up',
+        'check-out': 'fa-cloud-arrow-down',
+        'delete': 'fa-trash-can',
+        'export': 'fa-download',
+        'move': 'fa-folder-open',
+        'recover': 'fa-trash-arrow-up'
+    }
+
     render() {
         const { menuOptions, anchorEl, onClose, placement } = this.props
 
@@ -12,17 +38,24 @@ export default class PopupMenu extends Component {
             const key = `menugroup-${menuOption.id}`
             const onClick = () => {
                 menuOption.action()
-            }    
+            }
+            if (menuOption.id === 'delete') {
+                menuItems.push(<StyledDivider component="li" key="divider" light />)
+            }
+            const icon = this.MENU_ICONS[menuOption.id] || '';
             menuItems.push(
-                <MenuItem 
+                <StyledMenuItem
                     onClick={onClick}
-                    key={key} 
-                    className="menu-item"
+                    key={key}
+                    className={`menu-item ${menuOption.classes || ''}`}
                     disabled={menuOption.disabled}
                     value={menuOption.id}
                 >
-                    {menuOption.label}
-                </MenuItem>
+                    <ListItemIcon>
+                        <i className={`fa ${icon}`}></i>
+                    </ListItemIcon>
+                    <ListItemText primary={menuOption.label} />
+                </StyledMenuItem>
             )
         }
         
@@ -30,7 +63,7 @@ export default class PopupMenu extends Component {
 
         return (
             <div id="PopupMenu">
-                <Menu                            
+                <Menu
                     open={true}
                     onClose={onClose}
                     anchorEl={anchorEl}

--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -121,6 +121,7 @@ export default class MainWindow extends Component {
       leftPaneWidth: initialLeftPaneWidth,
       rightPaneWidth: initialRightPaneWidth,
       migrateResourcesMode: false,
+      migratingResources: new Set(),
     };
   }
 
@@ -238,7 +239,24 @@ export default class MainWindow extends Component {
   onResourceEntryUpdated = (e, resourceEntry) => {
     const { fairCopyProject } = this.props;
     fairCopyProject.notifyListeners("resourceEntryUpdated", resourceEntry);
+    this.setState((prevState) => {
+      // if updated resource entry was part of migration in progress, mark it migrated
+      const migratingResources = new Set(prevState.migratingResources);
+      migratingResources.delete(resourceEntry.id);
+      return {
+        ...prevState,
+        migratingResources,
+      };
+    })
     this.refreshWindow();
+  };
+
+  onMigrateResource = (e, resourceID) => {
+    // add resource id to set of migration in progress resources
+    this.setState((prevState) => ({
+      ...prevState,
+      migratingResources: new Set(prevState.migratingResources).add(resourceID),
+    }));
   };
 
   onResourceContentUpdated = (e, resourceUpdate) => {
@@ -257,6 +275,10 @@ export default class MainWindow extends Component {
     fairCopy.ipcRegisterCallback(
       "resourceViewUpdate",
       this.onResourceViewUpdate
+    );
+    fairCopy.ipcRegisterCallback(
+      "resourceMigrationStarted",
+      this.onMigrateResource
     );
     fairCopy.ipcRegisterCallback("requestExitApp", this.onRequestExitApp);
     fairCopy.ipcRegisterCallback(
@@ -1056,6 +1078,7 @@ export default class MainWindow extends Component {
       resourceIndex,
       allResourcesCheckmarked,
       resourceCheckmarks,
+      migratingResources,
     } = this.state;
     const { currentView } = resourceViews;
     const resourceView = resourceViews[currentView];
@@ -1064,27 +1087,29 @@ export default class MainWindow extends Component {
     return (
       <div className="content-pane">
         {resourceBrowserOpen && (
-          <ResourceBrowser
-            onResourceAction={this.onResourceAction}
-            onOpenPopupMenu={this.onOpenPopupMenu}
-            onEditResource={this.onEditResource}
-            onEditTEIDoc={() => {
-              this.setState({ ...this.state, editTEIDocDialogMode: true });
-            }}
-            onImportResource={this.onImportResource}
-            onLogin={this.onLogin}
-            teiDoc={parentEntry}
-            setResourceCheckmark={this.setResourceCheckmark}
-            setAllCheckmarks={this.setAllCheckmarks}
-            allResourcesCheckmarked={allResourcesCheckmarked}
-            resourceCheckmarks={resourceCheckmarks}
-            onResourceViewChange={this.onResourceViewChange}
-            currentView={currentView}
-            resourceView={resourceView}
-            resourceIndex={resourceIndex}
-            fairCopyProject={fairCopyProject}
-            panelWidth={rightPaneWidth}
-          ></ResourceBrowser>
+          migratingResources.size > 0
+          ? <div id="ResourceBrowser">{bigRingSpinner()}</div>
+          : <ResourceBrowser
+              onResourceAction={this.onResourceAction}
+              onOpenPopupMenu={this.onOpenPopupMenu}
+              onEditResource={this.onEditResource}
+              onEditTEIDoc={() => {
+                this.setState({ ...this.state, editTEIDocDialogMode: true });
+              }}
+              onImportResource={this.onImportResource}
+              onLogin={this.onLogin}
+              teiDoc={parentEntry}
+              setResourceCheckmark={this.setResourceCheckmark}
+              setAllCheckmarks={this.setAllCheckmarks}
+              allResourcesCheckmarked={allResourcesCheckmarked}
+              resourceCheckmarks={resourceCheckmarks}
+              onResourceViewChange={this.onResourceViewChange}
+              currentView={currentView}
+              resourceView={resourceView}
+              resourceIndex={resourceIndex}
+              fairCopyProject={fairCopyProject}
+              panelWidth={rightPaneWidth}
+            ></ResourceBrowser>
         )}
         {this.renderEditors()}
       </div>

--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -31,6 +31,7 @@ import CheckInDialog from "./dialogs/CheckInDialog";
 import CheckOutDialog from "./dialogs/CheckOutDialog";
 import { bigRingSpinner } from "../common/ring-spinner";
 import { SplitPaneView } from "../common/SplitPaneView";
+import MigrateResourcesDialog from "./dialogs/MigrateResourcesDialog";
 
 const fairCopy = window.fairCopy;
 
@@ -119,6 +120,7 @@ export default class MainWindow extends Component {
       showSearchBar: false,
       leftPaneWidth: initialLeftPaneWidth,
       rightPaneWidth: initialRightPaneWidth,
+      migrateResourcesMode: false,
     };
   }
 
@@ -1131,6 +1133,7 @@ export default class MainWindow extends Component {
       draggingElementActive,
       moveResourceMode,
       editTEIDocDialogMode,
+      migrateResourcesMode,
       openResources,
       selectedResource,
       localResources,
@@ -1344,6 +1347,16 @@ export default class MainWindow extends Component {
             onLoggedIn={this.onLoggedIn}
           ></LoginDialog>
         )}
+        <MigrateResourcesDialog
+          fairCopyProject={fairCopyProject}
+          onClose={() => {
+            this.setState({
+              ...this.state,
+              migrateResourcesMode: false,
+            });
+          }}
+          open={migrateResourcesMode}
+        />
         <SnackAlert
           open={alertMessage !== null}
           message={alertMessage}

--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -31,7 +31,6 @@ import CheckInDialog from "./dialogs/CheckInDialog";
 import CheckOutDialog from "./dialogs/CheckOutDialog";
 import { bigRingSpinner } from "../common/ring-spinner";
 import { SplitPaneView } from "../common/SplitPaneView";
-import MigrateResourcesDialog from "./dialogs/MigrateResourcesDialog";
 
 const fairCopy = window.fairCopy;
 
@@ -120,7 +119,6 @@ export default class MainWindow extends Component {
       showSearchBar: false,
       leftPaneWidth: initialLeftPaneWidth,
       rightPaneWidth: initialRightPaneWidth,
-      migrateResourcesMode: false,
       migratingResources: new Set(),
     };
   }
@@ -1158,7 +1156,6 @@ export default class MainWindow extends Component {
       draggingElementActive,
       moveResourceMode,
       editTEIDocDialogMode,
-      migrateResourcesMode,
       openResources,
       selectedResource,
       localResources,
@@ -1372,16 +1369,6 @@ export default class MainWindow extends Component {
             onLoggedIn={this.onLoggedIn}
           ></LoginDialog>
         )}
-        <MigrateResourcesDialog
-          fairCopyProject={fairCopyProject}
-          onClose={() => {
-            this.setState({
-              ...this.state,
-              migrateResourcesMode: false,
-            });
-          }}
-          open={migrateResourcesMode}
-        />
         <SnackAlert
           open={alertMessage !== null}
           message={alertMessage}

--- a/src/render/components/main-window/dialogs/CheckInDialog.jsx
+++ b/src/render/components/main-window/dialogs/CheckInDialog.jsx
@@ -198,7 +198,7 @@ export default class CheckInDialog extends Component {
                    { this.renderCommitField() }
                    { this.renderResourceTable() }
                    { this.renderErrorMessage() }
-                </DialogContent>    
+                </DialogContent>
                 <DialogActions>
                     <Button {...checkInButtonProps} >Check In</Button>
                     <Button {...closeButtonProps} >{ status === 'ready' ? 'Cancel' : 'Done' }</Button>

--- a/src/render/components/main-window/dialogs/CheckInDialog.jsx
+++ b/src/render/components/main-window/dialogs/CheckInDialog.jsx
@@ -79,13 +79,14 @@ export default class CheckInDialog extends Component {
         const resourceRows = []
         for( const resource of resources ) {
             const { id: resourceID, type: resourceType, local, deleted, localID, name } = resource
-            // don't display header entries
-            if( resourceType === 'header' ) continue
+            // only display document entries
+            if( resourceType !== 'teidoc' ) continue
             const resourceStatusCode = resourceStatus ? resourceStatus[resourceID] : null
             const resourceStatusMessage = getResourceStatusMessage(resourceStatusCode)
             const editable = isEntryEditable(resource, fairCopyProject.userID)
             let { icon, label } = getActionIcon(responseReceived, local, editable )
-            if( deleted ) icon = 'fa-trash'
+            if( deleted ) icon = 'fa fa-trash'
+            if( local ) icon = 'fa fa-cloud-arrow-up'
 
             resourceRows.push(
                 <TableRow key={`resource-${resource.id}`}>
@@ -108,7 +109,7 @@ export default class CheckInDialog extends Component {
             )            
         }
 
-        const caption = status === 'done' ? 'These resources have been processed.' : 'These resources are ready to be checked in.'
+        const caption = status === 'done' ? 'These documents have been processed.' : 'These documents are ready to be checked in.'
 
         return (
             <div>
@@ -179,12 +180,12 @@ export default class CheckInDialog extends Component {
         const { onClose } = this.props
         const { status } = this.state
 
-        const checkInButtonProps = status === 'ready' ? {  variant: "contained", color: "primary", onClick: this.onCheckIn } : 
-            {  variant: "outlined", color: "default", enabled: 'false' } 
-        const closeButtonProps = status === 'done' ? {  variant: "contained", color: "primary", onClick: onClose } : 
-            status === 'loading' ?  {  variant: "outlined", color: "default", enabled: 'false' } : 
+        const checkInButtonProps = status === 'ready' ? {  variant: "contained", color: "primary", onClick: this.onCheckIn } :
+            {  variant: "outlined", color: "default", disabled: true }
+        const closeButtonProps = status === 'done' ? {  variant: "contained", color: "primary", onClick: onClose } :
+            status === 'loading' ?  {  variant: "outlined", color: "default", disabled: true } :
                                     {  variant: "outlined", color: "default", onClick: onClose }
-        
+
         return (
             <Dialog
                 id="CheckInDialog"
@@ -192,12 +193,12 @@ export default class CheckInDialog extends Component {
                 onClose={onClose}
                 aria-labelledby="checkin-dialog-title"
             >
-                <DialogTitle id="checkin-dialog-title">Check In Resources { status === 'loading' && inlineRingSpinner('dark') }</DialogTitle>
+                <DialogTitle id="checkin-dialog-title">Check In Documents { status === 'loading' && inlineRingSpinner('dark') }</DialogTitle>
                 <DialogContent className="checkin-panel">
                    { this.renderCommitField() }
                    { this.renderResourceTable() }
                    { this.renderErrorMessage() }
-                </DialogContent>
+                </DialogContent>    
                 <DialogActions>
                     <Button {...checkInButtonProps} >Check In</Button>
                     <Button {...closeButtonProps} >{ status === 'ready' ? 'Cancel' : 'Done' }</Button>

--- a/src/render/components/main-window/dialogs/CheckOutDialog.jsx
+++ b/src/render/components/main-window/dialogs/CheckOutDialog.jsx
@@ -13,14 +13,16 @@ export default class CheckOutDialog extends Component {
     renderResourceTable() {
         const { checkOutStatus } = this.props
         
-        let successCount = 0
+        let resourceCount = 0
         const resourceRows = []
         for( const statusEntry of checkOutStatus ) {
             const { state, resourceEntry } = statusEntry
             const { id, name, type, localID } = resourceEntry
-            if( type === 'header' ) continue
             const resourceStatusMessage = getResourceStatusMessage(state)
-            if( state === 'success' ) successCount++
+            if( type !== 'teidoc' ) {
+                if( state === 'success' && type !== 'header' ) resourceCount++
+                continue
+            }
 
             resourceRows.push(
                 <TableRow key={`resource-${id}`}>
@@ -37,13 +39,15 @@ export default class CheckOutDialog extends Component {
             )
         }
 
-        const s = successCount === 1 ? '' : 's'
+        const s = resourceCount === 1 ? '' : 's'
+        const docCount = checkOutStatus.filter(status => status.resourceEntry?.type === 'teidoc').length
+        const docCountMsg = `${docCount} document${docCount === 1 ? '' : 's'}`
 
         return (
             <div>
                 <TableContainer className="table-container">
                     <Table stickyHeader size="small" >
-                        <caption>Checked out {successCount} resource{s}.</caption>
+                        <caption>Checked out {docCountMsg}, totaling {resourceCount} resource{s}.</caption>
                         <TableHead>
                             <TableRow>
                                 <TableCell>Name</TableCell>
@@ -78,7 +82,7 @@ export default class CheckOutDialog extends Component {
                 onClose={onClose}
                 aria-labelledby="checkout-dialog-title"
             >
-                <DialogTitle id="checkout-dialog-title"><i aria-label="Checked Out Icon" className={`fa fa-pen fa-sm`}></i> Checked Out Resources</DialogTitle>
+                <DialogTitle id="checkout-dialog-title"><i aria-label="Checked Out Icon" className={`fa fa-pen fa-sm`}></i> Checked Out Documents</DialogTitle>
                 <DialogContent className="checkout-panel">
                    { this.renderResourceTable() }
                    { this.renderErrorMessage() }

--- a/src/render/components/main-window/dialogs/CheckOutDialog.jsx
+++ b/src/render/components/main-window/dialogs/CheckOutDialog.jsx
@@ -13,16 +13,14 @@ export default class CheckOutDialog extends Component {
     renderResourceTable() {
         const { checkOutStatus } = this.props
         
-        let resourceCount = 0
         const resourceRows = []
         for( const statusEntry of checkOutStatus ) {
             const { state, resourceEntry } = statusEntry
             const { id, name, type, localID } = resourceEntry
-            const resourceStatusMessage = getResourceStatusMessage(state)
             if( type !== 'teidoc' ) {
-                if( state === 'success' && type !== 'header' ) resourceCount++
                 continue
             }
+            const resourceStatusMessage = getResourceStatusMessage(state)
 
             resourceRows.push(
                 <TableRow key={`resource-${id}`}>
@@ -39,7 +37,6 @@ export default class CheckOutDialog extends Component {
             )
         }
 
-        const s = resourceCount === 1 ? '' : 's'
         const docCount = checkOutStatus.filter(status => status.resourceEntry?.type === 'teidoc').length
         const docCountMsg = `${docCount} document${docCount === 1 ? '' : 's'}`
 
@@ -47,7 +44,7 @@ export default class CheckOutDialog extends Component {
             <div>
                 <TableContainer className="table-container">
                     <Table stickyHeader size="small" >
-                        <caption>Checked out {docCountMsg}, totaling {resourceCount} resource{s}.</caption>
+                        <caption>Checked out {docCountMsg}.</caption>
                         <TableHead>
                             <TableRow>
                                 <TableCell>Name</TableCell>

--- a/src/render/components/main-window/dialogs/EditResourceDialog.jsx
+++ b/src/render/components/main-window/dialogs/EditResourceDialog.jsx
@@ -9,11 +9,11 @@ export default class EditResourceDialog extends Component {
 
     constructor(props) {
         super()
-        const { resourceEntry } = props
+        const { parentEntry, resourceEntry } = props
         this.initialState = resourceEntry ? { ...resourceEntry, validationErrors: {} } : {
             name: "",
             localID: "",
-            type: "text",
+            type: parentEntry ? "text" : "teidoc",
             validationErrors: {}
         }
         this.state = this.initialState
@@ -38,8 +38,6 @@ export default class EditResourceDialog extends Component {
     }
 
     renderResourceTypeSelect(type,onChange) {
-        const { parentEntry } = this.props
-
         return (
             <div>
                 <Typography color="textSecondary" >Resource Type</Typography>
@@ -70,18 +68,13 @@ export default class EditResourceDialog extends Component {
                             <span>A lineated transcription of a <br/>single source document.</span>
                         )}
                     </MenuItem>
-                    { !parentEntry && <MenuItem value={'teidoc'}>
-                        { this.renderTypeCard("TEI Document","fa fa-book-open",
-                            <span>A group of texts and facsimiles <br/>which share a common metadata <br/>description or a single text or <br/>facsimile which requires detailed <br/>metadata.</span>
-                        )}
-                    </MenuItem> }
                 </Select><br/>
             </div>
         )
     }
 
     render() {      
-        const { editDialogMode, onSave, onClose, resourceEntry } = this.props
+        const { editDialogMode, onSave, onClose, parentEntry, resourceEntry } = this.props
         
         const onChange = (e) => {
             const {name, value} = e.target
@@ -125,7 +118,8 @@ export default class EditResourceDialog extends Component {
             onClose()
         }
 
-        const dialogTitle = resourceEntry ? "Edit Resource" : "Create Resource"
+        const resourceType = (!parentEntry || resourceEntry?.type === "teidoc") ? "Document" : "Resource"
+        const dialogTitle = resourceEntry ? `Edit ${resourceType}` : `Create ${resourceType}`
 
         const { name, type, localID, validationErrors } = this.state
 
@@ -146,8 +140,8 @@ export default class EditResourceDialog extends Component {
                         onChange={onChange}
                         error={validationErrors['name'] !== undefined }
                         helperText={validationErrors['name']}
-                        aria-label="Resource Name"
-                        label="Resource Name" 
+                        aria-label={`${resourceType} Name`}
+                        label={`${resourceType} Name`}
                     /><br/>
                     <TextField 
                         name="localID"
@@ -159,7 +153,7 @@ export default class EditResourceDialog extends Component {
                         helperText={validationErrors['localID']}
                         label="ID" 
                     /><br/>
-                    { !resourceEntry && this.renderResourceTypeSelect(type,onChange) }
+                    { !resourceEntry && parentEntry && this.renderResourceTypeSelect(type,onChange) }
                 </DialogContent>
                 <DialogActions>
                     <Button variant="contained" color="primary" onClick={onSaveResource}>Save</Button>

--- a/src/render/components/main-window/dialogs/MigrateResourcesDialog.jsx
+++ b/src/render/components/main-window/dialogs/MigrateResourcesDialog.jsx
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@material-ui/core';
+
+const fairCopy = window.fairCopy
+
+export default class MigrateResourcesDialog extends Component {
+    onClose = () => {
+        fairCopy.ipcSend('closeProject')
+    }
+
+    onMigrate = () => {
+        const { onSuccess, fairCopyProject } = this.props
+        fairCopyProject.migrateOrphanedResources()
+        onSuccess()
+    }
+
+    render() {
+        const { open } = this.props
+        return (
+            <Dialog open={open} onClose={this.onClose} aria-labelledby="migrate-resources-dialog">
+                <DialogTitle id="migrate-resources-dialog">Project migration required</DialogTitle>
+                <DialogContent>
+                    <Typography>
+                        This project contains resources at the root level outside of any TEI document.
+                        To continue using this project, the resources must be moved into a TEI document.
+                    </Typography>
+                    <Typography>
+                        Click "Migrate" to move these resources and continue using the project.
+                    </Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button variant="outlined" onClick={this.onClose} color="primary">
+                        Close project
+                    </Button>
+                    <Button variant="contained" onClick={this.onMigrate} color="primary">
+                        Migrate
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        )
+    }
+}

--- a/src/render/components/main-window/dialogs/MoveResourceDialog.jsx
+++ b/src/render/components/main-window/dialogs/MoveResourceDialog.jsx
@@ -43,21 +43,7 @@ export default class MoveResourceDialog extends Component {
             scope: "row"
         }
 
-        if( !resource ) {    
-            const selected = targetID === 'ROOT' ? 'selected' : ''
-            return (
-                <TableRow hover onClick={onSelect} className={selected} dataresourceid='ROOT' key={`resource-ROOT`}>
-                    <TableCell {...cellProps} >
-                        <i className={`fa fa-home-alt fa-lg`}></i>
-                    </TableCell>
-                    <TableCell {...cellProps} >
-                        Project Home
-                    </TableCell>
-                    <TableCell {...cellProps} >
-                    </TableCell>
-                </TableRow>
-            )
-        } else {
+        if( resource ) {
             const selected = resource.id === targetID ? 'selected' : ''
             const resourceIcon = getResourceIcon(resource.type)
             const resourceLabel = getResourceIconLabel(resource.type)

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -194,14 +194,12 @@ export default class ResourceBrowser extends Component {
             </div>
             <div className="doc-header-right">
               <Tooltip title="Preview Published Document">
-                <span>
+                <span className="iconbutton-wrapper">
                   <IconButton
                     aria-label="Preview Published Document"
                     disabled={!canPreview}
                     onClick={onPreviewResource}
                     className='toolbar-button'
-                    disableRipple={true}
-                    disableFocusRipple={true}
                   >
                     <i className='fa fa-eye fa-md' />
                   </IconButton>

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -220,12 +220,8 @@ export default class ResourceBrowser extends Component {
                 <Button color="primary" disabled={!createAllowed} onClick={onEditResource} {...buttonProps}>
                   {teiDoc ? "New Resource" : "New Document"}
                 </Button>
-                {teiDoc &&
-                  <>
-                    <Button color="primary" disabled={!createAllowed} onClick={onImportXML} {...buttonProps}>Import Texts</Button>
-                    <Button color="primary" disabled={!createAllowed} onClick={onImportIIIF} {...buttonProps}>Import IIIF</Button>
-                  </>
-                }
+                <Button color="primary" disabled={!createAllowed} onClick={onImportXML} {...buttonProps}>Import Texts</Button>
+                <Button color="primary" disabled={!createAllowed} onClick={onImportIIIF} {...buttonProps}>Import IIIF</Button>
               </div>
             }
             <Button 

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -211,13 +211,21 @@ export default class ResourceBrowser extends Component {
           </div>
         }
         <div className='toolbar'>
-          <Typography component="h2" variant="h6">Resources</Typography>
+          <Typography component="h2" variant="h6">
+            {teiDoc ? "Resources" : "Documents"}
+          </Typography>
           <div className='tools'>
             { currentView === 'home' && 
               <div className='inline-button-group'>
-                <Button color="primary" disabled={!createAllowed} onClick={onEditResource} {...buttonProps}>New Resource</Button>    
-                <Button color="primary" disabled={!createAllowed} onClick={onImportXML} {...buttonProps}>Import Texts</Button>    
-                <Button color="primary" disabled={!createAllowed} onClick={onImportIIIF} {...buttonProps}>Import IIIF</Button>              
+                <Button color="primary" disabled={!createAllowed} onClick={onEditResource} {...buttonProps}>
+                  {teiDoc ? "New Resource" : "New Document"}
+                </Button>
+                {teiDoc &&
+                  <>
+                    <Button color="primary" disabled={!createAllowed} onClick={onImportXML} {...buttonProps}>Import Texts</Button>
+                    <Button color="primary" disabled={!createAllowed} onClick={onImportIIIF} {...buttonProps}>Import IIIF</Button>
+                  </>
+                }
               </div>
             }
             <Button 

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -262,7 +262,7 @@ export default class ResourceBrowser extends Component {
   }
 
   renderResourceTable() {
-    const { onResourceAction, fairCopyProject, resourceView, panelWidth, resourceIndex, currentView, resourceCheckmarks, allResourcesCheckmarked } = this.props
+    const { onResourceAction, fairCopyProject, resourceView, panelWidth, resourceIndex, currentView, resourceCheckmarks, allResourcesCheckmarked, teiDoc } = this.props
     const { remote: remoteProject, userID } = fairCopyProject
     const { currentPage, rowsPerPage, totalRows, orderBy, order } = resourceView
 
@@ -329,7 +329,7 @@ export default class ResourceBrowser extends Component {
           <TableCell {...cellProps} >
             <Checkbox onClick={onClickCheck} disabled={type === 'header'} dataresourceid={id} color="default" checked={check} />
           </TableCell>
-          { remoteProject && 
+          { remoteProject && !teiDoc && 
           <TableCell {...cellProps} align="center">
             { icon && 
               <Tooltip title={label}>
@@ -341,9 +341,11 @@ export default class ResourceBrowser extends Component {
             }
           </TableCell>
           }
-          <TableCell {...cellProps} >
-            <i aria-label={getResourceIconLabel(type)} className={`${resourceIcon} ${iconClass} fa-lg`}></i>
-          </TableCell>
+          { teiDoc &&
+            <TableCell {...cellProps} >
+              <i aria-label={getResourceIconLabel(type)} className={`${resourceIcon} ${iconClass} fa-lg`}></i>
+            </TableCell>
+          }
           <TableCell {...cellProps} >
             <Typography title={name} className={textClass}>{displayName}</Typography>
           </TableCell>
@@ -373,8 +375,8 @@ export default class ResourceBrowser extends Component {
                   <TableHead>
                       <TableRow>
                           <TableCell ><Checkbox onClick={toggleAll} color="default" checked={allResourcesCheckmarked} /></TableCell>
-                          { remoteProject && <TableCell align="center">Checked Out</TableCell> }
-                          <TableCell>Type</TableCell>
+                          { remoteProject && !teiDoc && <TableCell align="center">Checked Out</TableCell> }
+                          { teiDoc && <TableCell>Type</TableCell> }
                           { this.renderSortableHeaderCell('name','Name',orderBy,order) }
                           { this.renderSortableHeaderCell('localID','ID',orderBy,order) }
                           { remoteProject && <TableCell>Last Modified</TableCell> }

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -27,57 +27,68 @@ export default class ResourceBrowser extends Component {
 }
 
   onOpenActionMenu = (anchorEl) => {
-    const { onOpenPopupMenu, fairCopyProject, currentView } = this.props
-    const { remote: remoteProject, permissions } = fairCopyProject
+    const { currentView, fairCopyProject, onOpenPopupMenu, resourceCheckmarks, teiDoc } = this.props
+    const { permissions, remote: remoteProject, userID } = fairCopyProject
     const loggedIn = fairCopyProject.isLoggedIn()
-    const checkout = remoteProject ? canCheckOut(permissions) : true
     const del = remoteProject ? canDelete(permissions) : true
 
-    const remoteProjectOptions = !remoteProject || !loggedIn ? [] : [
-      {
-        id: 'check-in',
-        label: 'Check In',
-        action: this.createResourceAction('check-in')
-      },
-      {
-        id: 'check-out',
-        label: 'Check Out',
-        action: this.createResourceAction('check-out'),
-        disabled: !checkout
-      }
-    ]
-    
-    const menuOptions = [
-      {
-        id: 'open',
-        label: 'Open',
-        action: this.createResourceAction('open')
-      },
-      ...remoteProjectOptions,
-      {
-        id: 'export',
-        label: 'Export',
-        action: this.createResourceAction('export')
-      },
-      {
-        id: 'delete',
-        label: 'Delete',
-        action: this.createResourceAction('delete'),
-        disabled: !del
-      }
-    ]
+    // list of non-null selected items so we can do .some() or .every() on them
+    const resources = Object.values(resourceCheckmarks).filter(Boolean);
+    const checkedOutByUser = resources.some(
+      (r) =>
+        r.lastAction?.action_type === 'check_out' &&
+        r.lastAction.user?.id === userID,
+    )
+    const someDeleted = resources.some((r) => r.deleted)
+    const allDeleted = resources.every((r) => r.deleted)
+    const menuOptions = []
 
-    // move only works with local resources 
-    if( currentView === 'home' ) {
+    // TODO: collapse Remote and Local into a single view. for now, check them separately
+    if (remoteProject && loggedIn && !teiDoc) {
+      // checkin/checkout only in remote project, at the project root, when we are logged in
+      if (currentView === 'home' || checkedOutByUser) {
+        // can check in if we are in Local, or we're in Remote but user has something checked out
+        menuOptions.push({
+          id: 'check-in',
+          label: 'Check In',
+          action: this.createResourceAction('check-in')
+        })
+      } else if (currentView === 'remote' && canCheckOut(permissions)) {
+        // can only check out from Remote
+        menuOptions.push({
+          id: 'check-out',
+          label: 'Check Out',
+          action: this.createResourceAction('check-out'),
+        })
+      }
+    }
+
+    menuOptions.push({
+      id: 'export',
+      label: 'Export',
+      action: this.createResourceAction('export')
+    })
+
+    // move only works with local resources, and not at the project root
+    if (currentView === 'home' && teiDoc) {
       menuOptions.push({
         id: 'move',
         label: 'Move',
-        action: this.createResourceAction('move')   
-      })     
+        action: this.createResourceAction('move')
+      })
+    }
+
+    if (del && !allDeleted) {
+      menuOptions.push({
+        id: 'delete',
+        label: 'Delete',
+        classes: 'danger',
+        action: this.createResourceAction('delete'),
+      })
     }
 
     // you can recover deleted items when logged out
-    if( remoteProject ) {
+    if (remoteProject && someDeleted) {
       menuOptions.push({
         id: 'recover',
         label: 'Recover',

--- a/src/render/components/main-window/tei-editor/ReadOnlyToolbar.jsx
+++ b/src/render/components/main-window/tei-editor/ReadOnlyToolbar.jsx
@@ -10,7 +10,7 @@ export default class ReadOnlyToolbar extends Component {
         const { teiDocument } = this.props
         const { fairCopyProject } = teiDocument
         const { userID, serverURL, projectID } = fairCopyProject
-        fairCopy.ipcSend('checkOut', userID, serverURL, projectID, [ teiDocument.resourceEntry ] )
+        fairCopy.ipcSend('checkOut', userID, serverURL, projectID, [ teiDocument.parentEntry ] )
     }
 
     onFind = () => {
@@ -28,7 +28,7 @@ export default class ReadOnlyToolbar extends Component {
         return (
             <div id="ReadOnlyToolbar">
                 <div className="leftgroup">
-                    { !header && <Button className="toolbar-button" disabled={disabled} onClick={this.onCheckOut} variant="outlined" size='small'>Check Out</Button> }
+                    { !header && <Button className="toolbar-button" disabled={disabled} onClick={this.onCheckOut} variant="outlined" size='small'>Check Out Document</Button> }
                     { <Button className="toolbar-button" onClick={this.onFind} variant="outlined" size='small'><i className='fas fa-magnifying-glass'></i> Search</Button> }
                 </div>
                 <div className="rightgroup">

--- a/src/render/css/ResourceBrowser.css
+++ b/src/render/css/ResourceBrowser.css
@@ -80,3 +80,7 @@
     align-items: center;
     gap: 16px;
 }
+
+#ResourceBrowser span.iconbutton-wrapper {
+    cursor: pointer;
+}

--- a/src/render/model/FairCopyProject.js
+++ b/src/render/model/FairCopyProject.js
@@ -290,13 +290,22 @@ export default class FairCopyProject {
         return Object.values(resources).filter((r) => r.type !== 'teidoc' && !r.parentResource)    
     }
 
+    startMigratingResource = (resourceID) => {
+        fairCopy.ipcSend('startMigratingResource', resourceID)
+    }
+
     migrateOrphanedResources = () => {
         // v1.2.1 migration: move orphaned resources into new TEI document
+        this.orphanedResources.forEach((resourceEntry) => {
+            // queue each for migration, enabling loading spinner
+            this.startMigratingResource(resourceEntry.id)
+        })
         const docName = this.projectName
-        const existingIDs = Object.keys(this.idMap?.idMap || {})
+        const existingIDs = Object.keys(this.idMap.idMap)
         const localID = getUniqueResourceID('teidoc', existingIDs, docName)
         const teidoc = this.newResource(docName, localID, 'teidoc', null)
         this.orphanedResources.forEach((resourceEntry) => {
+            // move each into tei doc, ultimately disabling loading spinner
             resourceEntry.parentResource = teidoc.id
             this.updateResource(resourceEntry)
         })

--- a/src/render/model/FairCopyProject.js
+++ b/src/render/model/FairCopyProject.js
@@ -89,6 +89,7 @@ export default class FairCopyProject {
         this.projectID = fairCopyManifest.projectID
         this.permissions = fairCopyManifest.permissions
         this.configLastAction = fairCopyManifest.configLastAction
+        this.orphanedResources = this.getOrphanedResources(fairCopyManifest.resources)
     }
     
     updateResource( resourceEntry ) {
@@ -135,6 +136,7 @@ export default class FairCopyProject {
         } else {
             throw new Error("Attempted to create unknown document type.")
         }
+        return resourceEntry
     }
 
     removeResources( resourceIDs ) {
@@ -281,6 +283,24 @@ export default class FairCopyProject {
     isLoggedIn = () => {
         if( !this.remote ) return false
         return isLoggedIn( this.userID, this.serverURL )
+    }
+
+    getOrphanedResources = (resources) => {
+        // v1.2.1 migration: check for orphaned resources
+        return Object.values(resources).filter((r) => r.type !== 'teidoc' && !r.parentResource)    
+    }
+
+    migrateOrphanedResources = () => {
+        // v1.2.1 migration: move orphaned resources into new TEI document
+        const docName = this.projectName
+        const existingIDs = Object.keys(this.idMap?.idMap || {})
+        const localID = getUniqueResourceID('teidoc', existingIDs, docName)
+        const teidoc = this.newResource(docName, localID, 'teidoc', null)
+        this.orphanedResources.forEach((resourceEntry) => {
+            resourceEntry.parentResource = teidoc.id
+            this.updateResource(resourceEntry)
+        })
+        this.orphanedResources = []
     }
 }
 


### PR DESCRIPTION
### In this PR

- Update version control UI to only be applicable to TEI documents
   - Update check in and check out dialogs to filter out non-doc resources
- Prevent non-TEI doc resources from being created or moved outside of a TEI doc (i.e. at the root level)
   - Create a migration function, which a user initiates via a dialog, to move them into a doc with the project name
   - Prevent user from interacting during migration via loading spinner
   - Remove the import IIIF/import TEI buttons from the project root; remove type selector from new resource dialog there too
- Update action menu UIs to conditionally render options based on what's applicable to the selected item(s)
   - Also include icons in this menu per designs
- Only show "Type" in browse tables if we're inside a document; only show "Checked Out" if we're looking at the list of documents

### Notes

For the loading spinner, I kept track of each individual resource ID being moved (using Set and prevState to prevent any duplicates or race conditions). This is based on my understanding that resource moving logic is async, because it happens on a separate thread from the main window, meaning that we can only know to remove the loading spinner once every resource has certainly been migrated.

If this process is actually _synchronous_ and I've misunderstood that, we can simplify by removing the loading spinner after `updateResource` is called for each item.

<details>
<summary> Questions (answered)</summary>

- Should I prevent user interactions until the migration has fully completed? It actually can take a little while and you can visually see the UI update as resources are created and moved, so maybe we should disable things while that's happening
- Is it still worth listing the number of resources inside checked out documents, after a successful checkout?

**Decisions from meeting 8/11**:
- Yes, prevent user interactions with a spinner
- No, remove the resource count

</details>