### PR TITLE
Unlock / abandon checkout

### DIFF
--- a/src/main-process/FairCopyApplication.js
+++ b/src/main-process/FairCopyApplication.js
@@ -88,9 +88,9 @@ class FairCopyApplication {
     ipcMain.on('replaceTEIDocument', (event, resources) => { this.fairCopySession.replaceTEIDocument(resources) })
     ipcMain.on('replaceResource', (event, resource, parentEntry) => { this.fairCopySession.replaceResource(resource,parentEntry) })
 
-    ipcMain.on('removeResources', (event, resourceIDs) => { 
-      this.fairCopySession.removeResources(resourceIDs) 
-      
+    ipcMain.on('removeResources', (event, resourceIDs, forceDelete = false) => { 
+      this.fairCopySession.removeResources(resourceIDs, forceDelete) 
+
       // close any open image windows
       for( const resourceID of resourceIDs ) {
         const imageView = this.imageViews[resourceID]
@@ -243,6 +243,10 @@ class FairCopyApplication {
 
     ipcMain.on('abandon', (event, resourceEntries) => {
       this.fairCopySession.abandonCheckout(resourceEntries[0])
+    })
+
+    ipcMain.on('read-resources', (event, resourceIDs, abandoned) => {
+      this.fairCopySession.readResources(resourceIDs, abandoned)
     })
   
   }

--- a/src/main-process/FairCopyApplication.js
+++ b/src/main-process/FairCopyApplication.js
@@ -240,6 +240,10 @@ class FairCopyApplication {
         this.openProject(targetFile)
       }
     })
+
+    ipcMain.on('abandon', (event, resourceEntries) => {
+      this.fairCopySession.abandonCheckout(resourceEntries[0])
+    })
   
   }
 

--- a/src/main-process/FairCopySession.js
+++ b/src/main-process/FairCopySession.js
@@ -191,7 +191,7 @@ class FairCopySession {
         return true
     }
 
-    removeResources(resourceIDs) {
+    removeResources(resourceIDs, forceDelete) {
         const { resources } = this.projectStore.manifestData
         // use this map to generate unique ID list
         const doomedIDMap = {} 
@@ -216,7 +216,7 @@ class FairCopySession {
 
         const doomedIDs = Object.keys(doomedIDMap)
         const idMap = this.idMapAuthority.removeResources(doomedIDs)
-        this.projectStore.removeResources(doomedIDs,idMap)   
+        this.projectStore.removeResources(doomedIDs,idMap,forceDelete)
         this.requestResourceView()
     }
 
@@ -272,10 +272,57 @@ class FairCopySession {
         this.requestResourceView()
     }
 
-    requestResourceView(published) {
+    getCurrentResourceIndex() {
         const {currentView} = this.resourceViews
         const resourceView = this.resourceViews[currentView]
         const { indexParentID, currentPage, rowsPerPage } = resourceView
+        const { nameFilter, order, orderBy } = resourceView
+        const { resources: localResources } = this.projectStore.manifestData
+        const sortedResources = Object.values(localResources).sort((a,b) => {
+            const valueA = a[orderBy].toUpperCase()
+            const valueB = b[orderBy].toUpperCase()
+            if( valueA === valueB ) return 0
+            if( order == 'ascending' ) {
+                return valueA > valueB ? 1 : -1
+            } else {
+                return valueA < valueB ? 1 : -1
+            }
+        })
+
+        let resourceIndex = []
+        for( const localResource of sortedResources ) {
+            const { parentResource } = localResource
+            if( localResource.type !== 'image' ) {
+                // if this resource is a child of current parent OR 
+                // if the parent is not checked out, display it at top level
+                if( parentResource === indexParentID ||
+                    ( indexParentID === null && !localResources[parentResource] )) {
+                    if( indexParentID ) {
+                        // filter doesn't act on teidoc views
+                        resourceIndex.push(localResource)                    
+                    } else if( !nameFilter || localResource.name.includes(nameFilter) ) {
+                        resourceIndex.push(localResource)                    
+                    }
+                }
+            } 
+        }
+        // don't let currentPage be > page count 
+        let pageCount = Math.ceil(resourceIndex.length/rowsPerPage)
+        pageCount = pageCount === 0 ? 1 : pageCount
+        const nextPage = currentPage > pageCount ? pageCount : currentPage
+        const start = rowsPerPage * (nextPage-1)
+        const end = start + rowsPerPage
+        resourceView.totalRows = resourceIndex.length
+        resourceView.currentPage = nextPage
+        resourceView.loading = false
+        this.resourceViews[currentView] = resourceView
+        return resourceIndex.slice(start,end)
+    }
+
+    requestResourceView(published) {
+        const {currentView} = this.resourceViews
+        const resourceView = this.resourceViews[currentView]
+        const { indexParentID } = resourceView
         const { resources: localResources } = this.projectStore.manifestData
 
         if( currentView === 'remote' ) {
@@ -284,47 +331,7 @@ class FairCopySession {
         } else {
             // respond right away from project store
             resourceView.parentEntry = indexParentID ? localResources[indexParentID] : null
-            const { nameFilter, order, orderBy } = resourceView
-            const sortedResources = Object.values(localResources).sort((a,b) => {
-                const valueA = a[orderBy].toUpperCase()
-                const valueB = b[orderBy].toUpperCase()
-                if( valueA === valueB ) return 0
-                if( order == 'ascending' ) {
-                    return valueA > valueB ? 1 : -1
-                } else {
-                    return valueA < valueB ? 1 : -1
-                }
-            })
-
-            let resourceIndex = []
-            for( const localResource of sortedResources ) {
-                const { parentResource } = localResource
-                if( localResource.type !== 'image' ) {
-                    // if this resource is a child of current parent OR 
-                    // if the parent is not checked out, display it at top level
-                    if( parentResource === indexParentID ||
-                        ( indexParentID === null && !localResources[parentResource] )) {
-                        if( indexParentID ) {
-                            // filter doesn't act on teidoc views
-                            resourceIndex.push(localResource)                    
-                        } else if( !nameFilter || localResource.name.includes(nameFilter) ) {
-                            resourceIndex.push(localResource)                    
-                        }
-                    }
-                } 
-            }
-            // don't let currentPage be > page count 
-            let pageCount = Math.ceil(resourceIndex.length/rowsPerPage)
-            pageCount = pageCount === 0 ? 1 : pageCount
-            const nextPage = currentPage > pageCount ? pageCount : currentPage
-            const start = rowsPerPage * (nextPage-1)
-            const end = start + rowsPerPage
-            resourceView.totalRows = resourceIndex.length
-            resourceView.currentPage = nextPage
-            resourceView.loading = false
-            this.resourceViews[currentView] = resourceView
-            resourceIndex = resourceIndex.slice(start,end)
-
+            const resourceIndex = this.getCurrentResourceIndex()
             this.fairCopyApplication.sendToAllWindows('resourceViewUpdate', { resourceViews: this.resourceViews, resourceIndex } )
         }
     }
@@ -414,6 +421,10 @@ class FairCopySession {
         } else {
             this.projectStore.openResource(resourceID, xmlID)
         }
+    }
+
+    readResources(resourceIDs, abandoned) {
+        this.projectStore.readResources(resourceIDs, abandoned)
     }
 
     resourceOpened(resourceEntry, parentEntry, resource, xmlID) {

--- a/src/main-process/FairCopySession.js
+++ b/src/main-process/FairCopySession.js
@@ -563,6 +563,10 @@ class FairCopySession {
     requestEditionCrafterData(url) {
         return this.projectStore.requestEditionCrafterData(url)
     }
+
+    abandonCheckout(resource) {
+        this.remoteProject.abandonCheckout(resource)
+    }
 }
 
 exports.FairCopySession = FairCopySession

--- a/src/main-process/ProjectStore.js
+++ b/src/main-process/ProjectStore.js
@@ -41,6 +41,15 @@ class ProjectStore {
                         this.fairCopyApplication.fairCopySession.resourceOpened( resourceEntry, parentEntry, resource, xmlID )
                     }
                     break
+                case 'resources-data':
+                    {
+                        const { resources, abandoned } = msg
+                        if (abandoned) {
+                            this.fairCopyApplication.sendToMainWindow('abandonedResourcesData', resources)
+                        }
+                        // can do other things with resource data here; each will be an object { resourceID, content }
+                    }
+                    break
                 case 'index-resource':
                     {
                         const { resourceID, resource } = msg
@@ -271,7 +280,7 @@ class ProjectStore {
         }
     }
     
-    removeResources(resourceIDs,idMap) {
+    removeResources(resourceIDs, idMap, forceDelete) {
         for( const resourceID of resourceIDs ) {
             const resourceEntry = this.manifestData.resources[resourceID]
         
@@ -289,13 +298,15 @@ class ProjectStore {
                 // remove associated search index
                 if( this.searchIndex ) this.searchIndex.removeIndex(resourceID)
             }
-    
-            if( resourceEntry.local ) {
-                delete this.manifestData.resources[resourceID] 
+
+            // remove file from local, if local-only or forced deletion (i.e. abandoned resource)
+            if( resourceEntry.local || forceDelete ) {
+                delete this.manifestData.resources[resourceID]
                 if( resourceEntry.type !== 'teidoc' ) {
                     this.projectArchiveWorker.postMessage({ messageType: 'remove-file', fileID: resourceID })
                 }
             } else {
+                // otherwise just set deleted flag
                 resourceEntry.deleted = true
                 this.fairCopyApplication.sendToAllWindows('resourceEntryUpdated', resourceEntry )
             }
@@ -400,6 +411,10 @@ class ProjectStore {
         if( resourceEntry ) {
             this.projectArchiveWorker.postMessage({ messageType: 'read-resource', resourceID, xmlID })
         }
+    }
+
+    readResources(resourceIDs, abandoned) {
+        this.projectArchiveWorker.postMessage({ messageType: 'read-resources', resourceIDs, abandoned })
     }
 
     checkOutResults(resources,error) {        

--- a/src/main-process/RemoteProject.js
+++ b/src/main-process/RemoteProject.js
@@ -114,6 +114,10 @@ class RemoteProject {
     publish(teiDoc) {
         this.remoteProjectWorker.postMessage({ messageType: 'publish', teiDoc })
     }
+
+    abandonCheckout(resource) {
+        this.remoteProjectWorker.postMessage({ messageType: 'abandon', resource })
+    }
 }
 
 

--- a/src/main-process/RemoteProject.js
+++ b/src/main-process/RemoteProject.js
@@ -5,11 +5,17 @@ const { app } = require('electron')
 class RemoteProject {
 
     constructor( fairCopySession, userID, serverURL, projectID ) {
-        const { fairCopyApplication } = fairCopySession
+        const { fairCopyApplication, resourceViews } = fairCopySession
+        const { currentView } = resourceViews
+        const resourceView = resourceViews[currentView]
         const {baseDir} = fairCopyApplication
         this.fairCopySession = fairCopySession
         this.initRemoteProjectWorker( baseDir, !app.isPackaged, userID, serverURL, projectID ).then(() => {
             this.open()
+            if (currentView === 'home' && !resourceView?.indexParentID) {
+                // at local project root, on remote project worker launch, check for abandoned resources
+                this.markAbandonedResources(fairCopySession.getCurrentResourceIndex(), resourceViews['home'])
+            }
         })
     }
 
@@ -75,11 +81,36 @@ class RemoteProject {
                     this.fairCopySession.requestResourceView(published)
                 }
                 break
+                case 'process-abandoned':
+                {
+                    const { fairCopyApplication, projectStore } = this.fairCopySession
+                    const { localResources, remoteResources } = msg
+                    const abandoned = localResources?.filter((resource) => {
+                        if (resource.type !== 'teidoc') return false
+                        const remoteResource = remoteResources?.find((r) => r.id === resource.id)
+                        if (remoteResource) {
+                            // mismatched action type, or action type is the same but user ID is different,
+                            // means this is probably an abandoned resource
+                            return (
+                                resource.lastAction?.action_type !== remoteResource.lastAction?.action_type ||
+                                resource.lastAction?.user?.id !== remoteResource.lastAction?.user?.id
+                            )
+                        }
+                        return false
+                    })
+                    const abandonedIDs = abandoned.map((r) => r.id)
+                    const { resources } = projectStore.manifestData
+                    const abandonedChildren = Object.values(resources)?.filter((r) => abandonedIDs.includes(r.parentResource))
+                    if (abandoned.length > 0) {
+                        fairCopyApplication.sendToMainWindow('markAbandoned', [...abandoned, ...abandonedChildren])
+                    }
+                }
+                break
                 default:
                     throw new Error(`Unrecognized message type ${messageType} received from remote project: ${JSON.stringify(msg)}`)
             }
         })
-        
+
         return this.remoteProjectWorker.start({userID, serverURL, projectID})
     }
 
@@ -117,6 +148,10 @@ class RemoteProject {
 
     abandonCheckout(resource) {
         this.remoteProjectWorker.postMessage({ messageType: 'abandon', resource })
+    }
+
+    markAbandonedResources(resources, resourceView) {
+        this.remoteProjectWorker.postMessage({ messageType: 'check-abandoned', resources, resourceView })
     }
 }
 

--- a/src/render/components/common/PopupMenu.jsx
+++ b/src/render/components/common/PopupMenu.jsx
@@ -25,6 +25,7 @@ export default class PopupMenu extends Component {
         'delete': 'fa-trash-can',
         'export': 'fa-download',
         'move': 'fa-folder-open',
+        'abandon': 'fa-lock-open',
         'recover': 'fa-trash-arrow-up'
     }
 
@@ -39,7 +40,7 @@ export default class PopupMenu extends Component {
             const onClick = () => {
                 menuOption.action()
             }
-            if (menuOption.id === 'delete') {
+            if (menuOption.id === 'delete' || menuOption.id === 'abandon') {
                 menuItems.push(<StyledDivider component="li" key="divider" light />)
             }
             const icon = Object.hasOwn(this.MENU_ICONS, menuOption.id) ? this.MENU_ICONS[menuOption.id] : ''

--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -31,6 +31,7 @@ import CheckInDialog from "./dialogs/CheckInDialog";
 import CheckOutDialog from "./dialogs/CheckOutDialog";
 import { bigRingSpinner } from "../common/ring-spinner";
 import { SplitPaneView } from "../common/SplitPaneView";
+import AbandonedResourcesDialog from "./dialogs/AbandonedResourcesDialog";
 
 const fairCopy = window.fairCopy;
 
@@ -122,6 +123,8 @@ export default class MainWindow extends Component {
       rightPaneWidth: initialRightPaneWidth,
       migratingResources: new Set(),
       publishingResources: false,
+      abandonedDialogMode: false,
+      abandonedLocalResources: [],
     };
   }
 
@@ -282,6 +285,43 @@ export default class MainWindow extends Component {
     }));
   }
 
+  onMarkAbandoned = (e, resources) => {
+    this.setState((prevState) => ({
+      ...prevState,
+      abandonedDialogMode: true,
+      abandonedLocalResources: resources,
+    }))
+  }
+
+  onReceiveAbandonedResourcesData = (e, resources) => {
+    const { fairCopyProject } = this.props;
+    const { abandonedLocalResources } = this.state
+
+    // should be here from "create new" option in abandoned resources dialog, which kicked off
+    // a read operation for each resource's contents; if not, bail
+    if (!abandonedLocalResources) {
+      return
+    }
+
+    // merge local resources with content
+    const resourceMap = new Map(resources.map(r => [r.resourceID, r.content]))
+    const localWithContent = abandonedLocalResources.map((resource) => ({
+      ...resource,
+      content: resourceMap.get(resource.id)
+    }))
+
+    // kick off "create new" operation and deletion of originals
+    fairCopyProject.duplicateDocuments(localWithContent)
+    const abandonedDocs = abandonedLocalResources.filter((r) => r.type === "teidoc")
+    fairCopyProject.forceDeleteResources(abandonedDocs)
+
+    this.setState((prevState) => ({
+      ...prevState,
+      abandonedDialogMode: false,
+      abandonedLocalResources: [],
+    }))
+  }
+
   onResourceContentUpdated = (e, resourceUpdate) => {
     const { fairCopyProject } = this.props;
     fairCopyProject.notifyListeners("resourceContentUpdated", resourceUpdate);
@@ -323,6 +363,11 @@ export default class MainWindow extends Component {
       "publishingResourceStarted",
       this.onPublishResource
     );
+    fairCopy.ipcRegisterCallback("markAbandoned", this.onMarkAbandoned);
+    fairCopy.ipcRegisterCallback(
+      "abandonedResourcesData",
+      this.onReceiveAbandonedResourcesData
+    );
   }
 
   componentWillUnmount() {
@@ -348,6 +393,11 @@ export default class MainWindow extends Component {
     fairCopy.ipcRemoveListener(
       "publishingResourceStarted",
       this.onPublishResource
+    );
+    fairCopy.ipcRemoveListener("markAbandoned", this.onMarkAbandoned);
+    fairCopy.ipcRemoveListener(
+      "abandonedResourcesData",
+      this.onReceiveAbandonedResourcesData
     );
   }
 
@@ -1219,6 +1269,8 @@ export default class MainWindow extends Component {
 
   renderDialogs() {
     const {
+      abandonedDialogMode,
+      abandonedLocalResources,
       editDialogMode,
       searchFilterMode,
       searchFilterOptions,
@@ -1289,6 +1341,24 @@ export default class MainWindow extends Component {
         surfaceInfo: null,
         editSurfaceInfoMode: false,
       });
+    };
+
+    const onCreateFromAbandoned = () => {
+      // create duplicates of local copies of abandoned resources, then delete
+      const resourceIDs = abandonedLocalResources.map((r) => r.id)
+      // need to read contents of each in order to create duplicates
+      fairCopy.ipcSend("read-resources", resourceIDs, true)
+    };
+
+    const onDeleteAbandoned = () => {
+      // immediately force-delete local copies of abandoned resources
+      const abandonedDocs = abandonedLocalResources.filter((r) => r.type === "teidoc")
+      fairCopyProject.forceDeleteResources(abandonedDocs)
+      this.setState((prevState) => ({
+        ...prevState,
+        abandonedDialogMode: false,
+        abandonedLocalResources: [],
+      }));
     };
 
     return (
@@ -1449,6 +1519,13 @@ export default class MainWindow extends Component {
             serverURL={serverURL}
             onLoggedIn={this.onLoggedIn}
           ></LoginDialog>
+        )}
+        {abandonedDialogMode && (
+          <AbandonedResourcesDialog
+            abandonedResources={abandonedLocalResources}
+            onCreateFromAbandoned={onCreateFromAbandoned}
+            onDelete={onDeleteAbandoned}
+          ></AbandonedResourcesDialog>
         )}
         <SnackAlert
           open={alertMessage !== null}

--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -879,6 +879,18 @@ export default class MainWindow extends Component {
         fairCopy.ipcSend("requestExport", resourceEntries);
         this.setState({ ...nextState, ...closePopUpState });
         break;
+      case "abandon":
+        const alertOptions = {
+          onAbandon: () => fairCopy.ipcSend("abandon", resourceEntries),
+          resource: resourceEntries[0],
+        }
+        this.setState({
+          ...nextState,
+          alertDialogMode: "confirmAbandonCheckout",
+          alertOptions,
+          ...closePopUpState,
+        });
+        break;
       default:
         console.error(`Unrecognized resource action id: ${actionID}`);
         break;

--- a/src/render/components/main-window/dialogs/AbandonedResourcesDialog.jsx
+++ b/src/render/components/main-window/dialogs/AbandonedResourcesDialog.jsx
@@ -1,0 +1,71 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@material-ui/core'
+import React, { Component } from 'react'
+
+const fairCopy = window.fairCopy
+
+export default class AbandonedResourcesDialog extends Component {
+
+    onClose = () => {
+        fairCopy.ipcSend('closeProject')
+    }
+    render() {
+        const { abandonedResources, onDelete, onCreateFromAbandoned } = this.props
+
+        return (
+            <Dialog
+                id="AbandonedResourcesDialog"
+                open
+                onClose={this.onClose}
+                aria-labelledby="abandoned-dialog-title"
+            >
+                <DialogTitle id="abandoned-dialog-title">
+                    Local/Remote Document Mismatch
+                </DialogTitle>
+                <DialogContent>
+                    <Typography gutterBottom>
+                        FairCopy has detected a mismatch between your local project files and the
+                        remote server.
+                    </Typography>
+                    <Typography gutterBottom>
+                        This may have occurred if an admin unlocked your checked-out documents for
+                        others to edit, or due to a client-server communication error.
+                    </Typography>
+                    <Typography>
+                        To continue using this project, you may choose one of two actions for these
+                        documents: <Typography variant="button" dispaly="inline">Delete</Typography> your
+                        local document copies entirely;
+                        or <Typography variant="button" dispaly="inline">Create New</Typography> ones
+                        from their contents (if you have unchecked-in changes you would like to preserve).
+                    </Typography>
+                    <TableContainer className="abandoned-table">
+                        <Table size="small" stickyHeader>
+                            <caption>Affected documents</caption>
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell>Name</TableCell>
+                                    <TableCell>ID</TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {abandonedResources.filter((r) => r.type === 'teidoc').map((resource) => (
+                                    <TableRow key={resource.id}>
+                                        <TableCell>
+                                            {resource.name}
+                                        </TableCell>
+                                        <TableCell>
+                                            {resource.localID}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                </DialogContent>
+                <DialogActions>
+                    <Button variant="contained" color="secondary" onClick={onDelete}>Delete</Button>
+                    <Button variant="contained" color="primary" onClick={onCreateFromAbandoned}>Create New</Button>
+                </DialogActions>
+            </Dialog>
+        )
+    }
+}

--- a/src/render/components/main-window/dialogs/AlertDialog.jsx
+++ b/src/render/components/main-window/dialogs/AlertDialog.jsx
@@ -175,6 +175,40 @@ export default class AlertDialog extends Component {
         return this.renderDialog( title, message, actions )
     }
 
+    renderConfirmAbandon() {
+        const { alertOptions, onCloseAlert } = this.props
+
+        const onAbandonCheckout = () => {
+            const { onAbandon } = alertOptions
+            onAbandon()
+            onCloseAlert()
+        }
+
+        const onCloseWithoutAbandon = () => {
+            onCloseAlert()
+        }
+
+        const { resource } = alertOptions
+        const resourceName = resource.name
+        const title = "Confirm Unlock"
+        const message = `Unlocking "${resourceName}" will force a check-in,
+            abandoning all local work by the user who checked it out. This
+            action cannot be undone. Are you sure you want to proceed?`
+        const actions = [
+            {
+                label: "Unlock",
+                defaultAction: true,
+                handler: onAbandonCheckout
+            },
+            {
+                label: "Cancel",
+                handler: onCloseWithoutAbandon
+            }
+        ]
+
+        return this.renderDialog( title, message, actions )
+    }
+
     render() {      
         const { alertDialogMode } = this.props
         switch(alertDialogMode) {
@@ -186,6 +220,8 @@ export default class AlertDialog extends Component {
                 return this.renderConfirmDelete()
             case 'confirmDeleteImages':
                 return this.renderConfirmDeleteImages()
+            case 'confirmAbandonCheckout':
+                return this.renderConfirmAbandon()
             case 'closed':
             default:
                 return null

--- a/src/render/components/main-window/dialogs/CheckInDialog.jsx
+++ b/src/render/components/main-window/dialogs/CheckInDialog.jsx
@@ -129,6 +129,7 @@ export default class CheckInDialog extends Component {
             const resourceStatusMessage = getResourceStatusMessage(resourceStatusCode)
             const editable = isEntryEditable(resource, fairCopyProject.userID)
             let { icon, label } = getActionIcon(responseReceived, local, editable )
+            if( resourceStatusCode && resourceStatusCode !== 'ok' ) icon = 'fa fa-x'
             if( deleted ) icon = 'fa fa-trash'
             if( local ) icon = 'fa fa-cloud-arrow-up'
 

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { Button, Card, Chip, InputAdornment, IconButton, TableContainer, TableSortLabel, Table, Input, TableHead, TableRow, TableCell, TableBody, TablePagination, Tooltip, Checkbox, Typography, CardContent, withStyles } from '@material-ui/core';
-import { Autorenew, Edit, Publish } from '@material-ui/icons';
+import { Autorenew, Edit, MoreVert, Publish } from '@material-ui/icons';
 import TitleBar from '../TitleBar'
 import { debounce } from "debounce";
 
 import { getResourceIcon, getActionIcon, getResourceIconLabel } from '../../../model/resource-icon';
 import { isEntryEditable, isCheckedOutRemote } from '../../../model/FairCopyProject'
-import { canCheckOut, canCreate, canDelete, isAdmin } from '../../../model/permissions'
+import { canAbandon, canCheckOut, canCreate, canDelete, isAdmin } from '../../../model/permissions'
 import { ellipsis } from '../../../model/ellipsis'
 
 const idealNameLength = 35
@@ -30,39 +30,42 @@ export default class ResourceBrowser extends Component {
     }, 100)
 }
 
-  onOpenActionMenu = (anchorEl) => {
+  onOpenActionMenu = (anchorEl, resource) => {
     const { currentView, fairCopyProject, onOpenPopupMenu, resourceCheckmarks, teiDoc } = this.props
     const { permissions, remote: remoteProject, userID } = fairCopyProject
     const loggedIn = fairCopyProject.isLoggedIn()
     const del = remoteProject ? canDelete(permissions) : true
 
     // list of non-null selected items so we can do .some() or .every() on them
-    const resources = Object.values(resourceCheckmarks).filter(Boolean);
+    const resources = resource ? [resource] : Object.values(resourceCheckmarks).filter(Boolean);
     const checkedOutByUser = resources.some(
       (r) =>
         r.lastAction?.action_type === 'check_out' &&
         r.lastAction.user?.id === userID,
     )
+    const someCheckedIn = resources.some((r) => r.lastAction?.action_type !== 'check_out')
     const someDeleted = resources.some((r) => r.deleted)
     const allDeleted = resources.every((r) => r.deleted)
     const menuOptions = []
 
     // TODO: collapse Remote and Local into a single view. for now, check them separately
-    if (remoteProject && loggedIn && !teiDoc) {
+    const atRemoteProjectRoot = remoteProject && loggedIn && !teiDoc;
+    if (atRemoteProjectRoot) {
       // checkin/checkout only in remote project, at the project root, when we are logged in
       if (currentView === 'home' || checkedOutByUser) {
         // can check in if we are in Local, or we're in Remote but user has something checked out
         menuOptions.push({
           id: 'check-in',
           label: 'Check In',
-          action: this.createResourceAction('check-in')
+          action: this.createResourceAction('check-in', resource)
         })
-      } else if (currentView === 'remote' && canCheckOut(permissions)) {
+      }
+      if (currentView === 'remote' && canCheckOut(permissions) && someCheckedIn) {
         // can only check out from Remote
         menuOptions.push({
           id: 'check-out',
           label: 'Check Out',
-          action: this.createResourceAction('check-out'),
+          action: this.createResourceAction('check-out', resource),
         })
       }
     }
@@ -70,7 +73,7 @@ export default class ResourceBrowser extends Component {
     menuOptions.push({
       id: 'export',
       label: 'Export',
-      action: this.createResourceAction('export')
+      action: this.createResourceAction('export', resource)
     })
 
     // move only works with local resources, and not at the project root
@@ -78,16 +81,29 @@ export default class ResourceBrowser extends Component {
       menuOptions.push({
         id: 'move',
         label: 'Move',
-        action: this.createResourceAction('move')
+        action: this.createResourceAction('move', resource)
       })
     }
 
-    if (del && !allDeleted) {
+    // if the resource is checked out by someone else, can abandon checkout
+    const isAbandonable = resource?.lastAction?.action_type === 'check_out' &&
+      resource.lastAction.user?.id !== userID
+    const showAbandon = canAbandon(permissions) && isAbandonable && atRemoteProjectRoot && currentView === 'remote'
+    if (showAbandon) {
+      menuOptions.push({
+        id: 'abandon',
+        label: 'Unlock',
+        classes: 'danger',
+        action: this.createResourceAction('abandon', resource),
+      })
+    }
+
+    if (del && !allDeleted && !showAbandon) {
       menuOptions.push({
         id: 'delete',
         label: 'Delete',
         classes: 'danger',
-        action: this.createResourceAction('delete'),
+        action: this.createResourceAction('delete', resource),
       })
     }
 
@@ -96,22 +112,27 @@ export default class ResourceBrowser extends Component {
       menuOptions.push({
         id: 'recover',
         label: 'Recover',
-        action: this.createResourceAction('recover')
+        action: this.createResourceAction('recover', resource)
       })
     }
     
     onOpenPopupMenu(menuOptions, anchorEl)
   }
 
-  createResourceAction(actionID) {    
+  createResourceAction(actionID, resource) {    
     return () => {
       const { onResourceAction, resourceCheckmarks } = this.props
       const resourceIDs = [], resourceEntries = []
-      for( const resourceID of Object.keys(resourceCheckmarks) ) {
-        const resourceEntry = resourceCheckmarks[resourceID]
-        if( resourceEntry ) {
-          resourceIDs.push(resourceEntry.id)
-          resourceEntries.push(resourceEntry)
+      if (resource) {
+        resourceIDs.push(resource.id)
+        resourceEntries.push(resource)
+      } else {
+        for( const resourceID of Object.keys(resourceCheckmarks) ) {
+          const resourceEntry = resourceCheckmarks[resourceID]
+          if( resourceEntry ) {
+            resourceIDs.push(resourceEntry.id)
+            resourceEntries.push(resourceEntry)
+          }
         }
       }
       onResourceAction(actionID, resourceIDs, resourceEntries)
@@ -421,6 +442,18 @@ export default class ResourceBrowser extends Component {
               </TableCell>
             </>
           }
+          <TableCell {...cellProps} >
+            <IconButton
+              aria-label="Actions"
+              disabled={resourceView.loading}
+              onClick={(event) => {
+                event.stopPropagation()
+                this.onOpenActionMenu(event.target, resource)
+              }}
+            >
+              <MoreVert />
+            </IconButton>
+          </TableCell>
         </TableRow>
       )
     }
@@ -446,6 +479,7 @@ export default class ResourceBrowser extends Component {
                           { remoteProject && !teiDoc && <TableCell>Last Modified</TableCell> }
                           { atRemoteRoot && <TableCell>Draft</TableCell> }
                           { atRemoteRoot && <TableCell>Published</TableCell> }
+                          <TableCell aria-label="Actions" />
                       </TableRow>
                   </TableHead>
                   <TableBody>

--- a/src/render/css/AbandonedResourcesInDialog.css
+++ b/src/render/css/AbandonedResourcesInDialog.css
@@ -1,0 +1,6 @@
+#AbandonedResourcesDialog .abandoned-table {
+    max-height: 300px !important;
+}
+#AbandonedResourcesDialog .abandoned-table caption {
+    caption-side: top;
+}

--- a/src/render/css/index.css
+++ b/src/render/css/index.css
@@ -69,3 +69,4 @@
 @import "SplitPaneView.css";
 @import "MainWindow.css";
 @import "ValidationReport.css";
+@import "AbandonedResourcesInDialog.css";

--- a/src/render/model/FairCopyProject.js
+++ b/src/render/model/FairCopyProject.js
@@ -311,6 +311,49 @@ export default class FairCopyProject {
         })
         this.orphanedResources = []
     }
+
+    duplicateDocuments = (localResources) => {
+        // duplicate resources and their children with new XML IDs and uuids
+        const teiDocs = localResources.filter((r) => r.type === 'teidoc')
+        teiDocs.forEach((parent) => {
+            // duplicate parent tei doc, with new guid and local id
+            const { id, localID, name } = parent
+            const existingIDs = Object.keys(this.idMap.idMap)
+            let newLocalID = getUniqueResourceID('teidoc', existingIDs, name)
+            const parentEntry = {
+                id: uuidv4(),
+                localID: newLocalID,
+                name, 
+                type: 'teidoc',
+                parentResource: null,
+                ...cloudInitialConfig
+            }
+            this.addResource(parentEntry, "", getBlankResourceMap(parentEntry.id, parentEntry.type))
+
+            // duplicate all of its children, assign to new parent
+            const children = localResources.filter((r) => r.parentResource === id)
+            const childLocalIDs = Object.keys(this.idMap.idMap[localID].ids)
+            children.forEach((child) => {
+                const { type: childType } = child
+                const newChildLocalID = getUniqueResourceID(childType, childLocalIDs, child.localID)
+                const childEntry = {
+                    id: uuidv4(),
+                    localID: newChildLocalID,
+                    name: child.name,
+                    type: childType,
+                    parentResource: parentEntry.id,
+                    ...cloudInitialConfig
+                }
+                this.addResource(childEntry, child.content, getBlankResourceMap(childEntry.id, childEntry.type))
+            })
+        })
+    }
+
+    forceDeleteResources = (localResources) => {
+        // fully delete local resources, even in a remote project 
+        const resourceIDs = localResources.map((r) => r.id)
+        fairCopy.ipcSend('removeResources', resourceIDs, true)
+    }
 }
 
 export function isEntryEditable( resourceEntry, userID ) {        

--- a/src/render/model/cloud-api/resource-management.js
+++ b/src/render/model/cloud-api/resource-management.js
@@ -110,3 +110,21 @@ export function checkOutResources(serverURL, authToken, projectID, resourceIDs) 
         )
     })
 }
+
+export function abandonCheckout(userID, serverURL, authToken, projectID, resource, onSuccess, onFail) {
+    // abandon check out on a resource
+    const data = { project_id: projectID, resource_guid: resource.id }
+
+    const checkInURL = `${serverURL}/api/resource_management/abandon`
+    axios.post(checkInURL, data,authConfig(authToken)).then(
+        (okResponse) => {
+            const { status } = okResponse.data
+            if( status === 'success' ) {
+                onSuccess()
+            } else {
+                onFail("Unable to unlock checked-out document.")
+            }
+        },
+        standardErrorHandler(userID, serverURL, onFail)
+    )
+}

--- a/src/render/model/permissions.js
+++ b/src/render/model/permissions.js
@@ -25,3 +25,8 @@ export function canDelete(permissions) {
     if( permissions.includes('FCC_CanDeleteResources')) return true
     return false
 }
+
+export function canAbandon(permissions) {
+    if( isAdmin(permissions) ) return true
+    return false
+}

--- a/src/render/workers/project-archive-worker.js
+++ b/src/render/workers/project-archive-worker.js
@@ -354,6 +354,20 @@ export function projectArchive( msg, workerMethods, workerData ) {
                 })
             }
             break
+        case 'read-resources':
+            {
+                // read the contents of all resources in resourceIDs, then pass back an array of
+                // objects { resourceID, content } to the main thread
+                const { resourceIDs, abandoned } = msg
+                Promise.all(
+                    resourceIDs.map((resourceID) =>
+                        readUTF8(resourceID, zip).then((content) => ({ resourceID, content }))
+                    )
+                ).then(resources => {
+                    postMessage({ messageType: 'resources-data', resources, abandoned })
+                })
+            }
+            break
         case 'request-index':
             {
                 const { resourceID } = msg

--- a/src/render/workers/remote-project-worker.js
+++ b/src/render/workers/remote-project-worker.js
@@ -5,6 +5,7 @@ import { getIDMap } from "../model/cloud-api/id-map"
 import { connectCable } from "../model/cloud-api/activity-cable"
 import { getConfig, initConfig, checkInConfig, checkOutConfig } from "../model/cloud-api/config"
 import { getTeiDocument, publishTeiDocument } from "../model/cloud-api/tei-documents"
+import { abandonCheckout } from "../model/cloud-api/resource-management"
 
 function updateIDMap( userID, serverURL, authToken, projectID, postMessage) {
     getIDMap( userID, serverURL, authToken, projectID, (idMapData) => {
@@ -197,6 +198,14 @@ export function remoteProject( msg, workerMethods, workerData ) {
         case 'publish':
             const { teiDoc } = msg
             onPublishTeiDocument(userID, serverURL, projectID, teiDoc, authToken, postMessage)
+            break
+        case 'abandon':
+            const { resource } = msg
+            abandonCheckout(userID, serverURL, authToken, projectID, resource, () => {
+                postMessage({ messageType: 'resources-updated', resources: [resource] })
+            }, (errorMessage) => {
+                console.log(errorMessage)
+            })
             break
         case 'close':
             close()

--- a/src/render/workers/remote-project-worker.js
+++ b/src/render/workers/remote-project-worker.js
@@ -207,6 +207,18 @@ export function remoteProject( msg, workerMethods, workerData ) {
                 console.log(errorMessage)
             })
             break
+        case 'check-abandoned':
+            {
+                const { resources: localResources, resourceView } = msg
+                const { currentPage, rowsPerPage, nameFilter, order, orderBy, indexParentID } = resourceView
+                getResources( userID, serverURL, authToken, projectID, indexParentID, currentPage, rowsPerPage, nameFilter, order, orderBy, (resourceData) => {
+                    const { remoteResources } = resourceData
+                    postMessage({ messageType: 'process-abandoned', localResources, remoteResources })
+                }, (errorMessage) => {
+                    console.log(errorMessage)
+                })
+            }
+            break
         case 'close':
             close()
             break            


### PR DESCRIPTION
### In this PR

- Show action menu per-resource in the table view
   - Modify `createResourceAction` to allow any action to apply to a single resource, by allowing it to act on a passed resource argument instead of just the checkboxes
- Add abandon checkout (Unlock) feature:
   - Allow admins to access it from the single-document action menu in the table only, since it can only be performed on one document
   - Show a dialog prompting user that it will abandon local work by the other user
   - On confirmation, send the `/resource_management/abandon` api call with the selected document
   - On success, refresh the remote resources
- Handle local abandoned resources
   - When the remote project worker loads, check local resources against remote list for mismatches
   - If mismatches found, display a message telling the user about it, and prompting them to create new resources with local resources' contents, or delete them
   - Create new: duplicates the abandoned resources, creating new TEI doc and sub-resources with the originals' contents (fetched in bulk from archive worker), and a new XML ID and guid. Then deletes the original abandoned resources as if they were local-only
   - Delete: just deletes the abandoned resources as if they were local-only

### Questions

<details>
<summary>Outdated: What should happen if a user's local resource has been abandoned/unlocked by another user?</summary>

Currently, in the browser it always shows the local resource, and shows it as being checked out, but check in and out are prevented. Effectively, the user permanently loses access to this document in the remote project.

One possible solution:
- When you load a remote project, immediately query remote resources from local home
- If there are any abandoned check outs (a remote resource that exists locally, but `lastAction.action_type === abandon_check_out`), put a ! on the document and mark it red
- Allow the user to discard their local copy of it entirely, and note that they won't be able to work with that document until they do

Maybe we should wait to resolve this until we consolidate the remote and local views? (I have a feeling that may end up being a can of worms though)

</details>

**Decision from meeting 8/11:**
- When you load local resources check them against the same resources on the remote
- If remote says it's checked in but user has it checked out, offer to user to create new resource with the same contents