### PR TITLE
"Check in all" button

### DIFF
--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -851,7 +851,22 @@ export default class MainWindow extends Component {
 
   onCheckInAll = () => {
     const { localResources } = this.state;
-    const resourceIDs = Object.keys(localResources);
+    // check in all TEI docs by id
+    const teiDocs = Object.entries(localResources).filter(
+      ([id, resource]) => resource.type === "teidoc" && !resource.parentResource
+    )
+    const resourceIDs = teiDocs.map(([id, resource]) => id);
+    // don't check in if there are unsaved files being committed
+    const { openResources } = this.state;
+    for (const resourceID of resourceIDs) {
+      const openResource = openResources[resourceID];
+      if (openResource && openResource.changedSinceLastSave) {
+        this.onAlertMessage(
+          "You must save all files that are being checked in."
+        );
+        return;
+      }
+    }
     this.setState((prevState) => ({
       ...prevState,
       checkInMode: true,

--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -97,6 +97,7 @@ export default class MainWindow extends Component {
       moveResourceMode: false,
       checkInMode: false,
       checkInResources: [],
+      checkInAll: false,
       editTEIDocDialogMode: false,
       moveResources: null,
       surfaceInfo: null,
@@ -848,6 +849,18 @@ export default class MainWindow extends Component {
     }
   };
 
+  onCheckInAll = () => {
+    const { localResources } = this.state;
+    const resourceIDs = Object.keys(localResources);
+    this.setState((prevState) => ({
+      ...prevState,
+      checkInMode: true,
+      checkInResources: resourceIDs,
+      checkInAll: true,
+      ...closePopUpState,
+    }));
+  }
+
   onSearchResults = (
     searchQuery,
     searchResults,
@@ -1095,6 +1108,7 @@ export default class MainWindow extends Component {
                 this.setState({ ...this.state, editTEIDocDialogMode: true });
               }}
               onImportResource={this.onImportResource}
+              onCheckInAll={this.onCheckInAll}
               onLogin={this.onLogin}
               teiDoc={parentEntry}
               setResourceCheckmark={this.setResourceCheckmark}
@@ -1144,6 +1158,7 @@ export default class MainWindow extends Component {
       searchFilterMode,
       searchFilterOptions,
       moveResourceProps,
+      checkInAll,
       checkInResources,
       checkOutMode,
       checkOutStatus,
@@ -1340,6 +1355,7 @@ export default class MainWindow extends Component {
           <CheckInDialog
             fairCopyProject={fairCopyProject}
             checkInResources={checkInResources}
+            checkInAll={checkInAll}
             localResources={localResources}
             onClose={() => {
               this.setState({ ...this.state, checkInMode: false });

--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -1358,7 +1358,7 @@ export default class MainWindow extends Component {
             checkInAll={checkInAll}
             localResources={localResources}
             onClose={() => {
-              this.setState({ ...this.state, checkInMode: false });
+              this.setState({ ...this.state, checkInMode: false, checkInAll: false });
             }}
           ></CheckInDialog>
         )}

--- a/src/render/components/main-window/TitleBar.jsx
+++ b/src/render/components/main-window/TitleBar.jsx
@@ -1,10 +1,27 @@
 import React, { Component } from 'react'
-import { Typography } from '@material-ui/core'
-import { IconButton, Tooltip } from '@material-ui/core'
+import { Typography, withStyles } from '@material-ui/core'
+import { Button, IconButton, Tooltip } from '@material-ui/core'
+import { common, indigo } from '@material-ui/core/colors'
 import { inlineRingSpinner } from '../common/ring-spinner'
 import { ellipsis } from '../../model/ellipsis'
 
 const maxTitleLength = 50
+
+const StyledButton = withStyles((theme) => ({
+    root: {
+        color: theme.palette.primary.dark,
+        backgroundColor: common.white,
+        '&:hover': {
+            backgroundColor: indigo[50],
+        },
+        '& .MuiButton-startIcon': {
+            marginLeft: 0,
+        },
+        '& .MuiButton-iconSizeMedium > *:first-child': {
+            fontSize: 16
+        }
+    },
+}))(Button)
 
 export default class TitleBar extends Component {
     
@@ -42,6 +59,23 @@ export default class TitleBar extends Component {
                     </IconButton> 
                 </span>
             </Tooltip>
+        )
+    }
+
+    renderVersionControl() {
+        const { canCheckInAll, currentView, onCheckInAll, remoteProject, parentResource } = this.props
+        return (
+            <>
+            {remoteProject && !parentResource && currentView === 'home' &&
+                <StyledButton
+                    disabled={!canCheckInAll}
+                    onClick={onCheckInAll}
+                    startIcon={<i className="fa fa-cloud-arrow-up fa-sm"></i>}
+                >
+                    Check in all
+                </StyledButton>
+            }
+            </>
         )
     }
 
@@ -84,9 +118,12 @@ export default class TitleBar extends Component {
         const secondaryWindow = isImageWindow || isPreviewWindow
 
         return (
-            <header id="TitleBar" >                
+            <header id="TitleBar" >
+                <div className="title-bar-left">
                     { !secondaryWindow && this.renderHomeButton() }
                     { this.renderTitle() }
+                </div>
+                { this.renderVersionControl() }
             </header>
         )
     }

--- a/src/render/components/main-window/dialogs/CheckInDialog.jsx
+++ b/src/render/components/main-window/dialogs/CheckInDialog.jsx
@@ -176,8 +176,22 @@ export default class CheckInDialog extends Component {
         )
     }
 
+    renderCheckInAll() {
+        const { committedResources, status } = this.state
+        const resourcesToCommit = this.getResourcesToCommit()
+        const responseReceived = status === 'done'
+        const resourceList = responseReceived ? committedResources : resourcesToCommit
+        const documentCount = resourceList.filter((resource) => resource.type === 'teidoc').length
+        const caption = status === 'done'
+            ? `${documentCount} documents have been processed.`
+            : `${documentCount} documents are ready to be checked in.`
+        return (
+            <Typography>{caption}</Typography>
+        )
+    }
+
     render() {
-        const { onClose } = this.props
+        const { onClose, checkInAll } = this.props
         const { status } = this.state
 
         const checkInButtonProps = status === 'ready' ? {  variant: "contained", color: "primary", onClick: this.onCheckIn } :
@@ -196,7 +210,8 @@ export default class CheckInDialog extends Component {
                 <DialogTitle id="checkin-dialog-title">Check In Documents { status === 'loading' && inlineRingSpinner('dark') }</DialogTitle>
                 <DialogContent className="checkin-panel">
                    { this.renderCommitField() }
-                   { this.renderResourceTable() }
+                   { !checkInAll && this.renderResourceTable() }
+                   { checkInAll && this.renderCheckInAll() }
                    { this.renderErrorMessage() }
                 </DialogContent>
                 <DialogActions>

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -166,7 +166,7 @@ export default class ResourceBrowser extends Component {
 
     const buttonProps = {
       className: 'toolbar-button',
-      variant: 'outlined',
+      variant: 'contained',
       size: 'small'
     }
 
@@ -215,9 +215,7 @@ export default class ResourceBrowser extends Component {
           <div className='tools'>
             { currentView === 'home' && 
               <div className='inline-button-group'>
-                <Button color="primary" variant="contained" disabled={!createAllowed} onClick={onEditResource} {...buttonProps}>
-                  {teiDoc ? "New Resource" : "New Document"}
-                </Button>
+                <Button color="primary" disabled={!createAllowed} onClick={onEditResource} {...buttonProps}>Add New</Button>
                 <Button color="primary" disabled={!createAllowed} onClick={onImportXML} {...buttonProps}>Import Texts</Button>
                 <Button color="primary" disabled={!createAllowed} onClick={onImportIIIF} {...buttonProps}>Import IIIF</Button>
               </div>
@@ -227,6 +225,8 @@ export default class ResourceBrowser extends Component {
               ref={(el)=> { this.actionButtonEl = el }}
               onClick={()=>{this.onOpenActionMenu(this.actionButtonEl)}}         
               {...buttonProps}
+              color='primary'
+              variant='outlined'
             >Actions<i className='down-caret fas fa-caret-down fa-lg'></i></Button>
             { !teiDoc && this.renderFilterInput() }
           </div>

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -215,7 +215,7 @@ export default class ResourceBrowser extends Component {
           <div className='tools'>
             { currentView === 'home' && 
               <div className='inline-button-group'>
-                <Button color="primary" disabled={!createAllowed} onClick={onEditResource} {...buttonProps}>
+                <Button color="primary" variant="contained" disabled={!createAllowed} onClick={onEditResource} {...buttonProps}>
                   {teiDoc ? "New Resource" : "New Document"}
                 </Button>
                 <Button color="primary" disabled={!createAllowed} onClick={onImportXML} {...buttonProps}>Import Texts</Button>
@@ -426,9 +426,9 @@ export default class ResourceBrowser extends Component {
   }
 
   render() {
-      const { width, teiDoc, fairCopyProject, onResourceAction, resourceView, currentView } = this.props
+      const { width, teiDoc, fairCopyProject, onResourceAction, resourceView, currentView, resourceIndex, onCheckInAll } = this.props
       const { loading } = resourceView
-      const { isLoggedIn, remote: remoteProject } = fairCopyProject
+      const { isLoggedIn, remote: remoteProject, permissions } = fairCopyProject
 
       // reset the filter when switching views
       const onResourceActionFilter = (actionID, resourceIDs, resourceEntries) => {
@@ -438,9 +438,20 @@ export default class ResourceBrowser extends Component {
         onResourceAction(actionID, resourceIDs, resourceEntries)
       }
 
+      const canCheckInAll = resourceIndex.length > 0 && remoteProject && canCheckOut(permissions)
+
       return (
         <div id="ResourceBrowser" style={{width: width ? width : '100%'}}>
-          <TitleBar parentResource={teiDoc} onResourceAction={onResourceActionFilter} isLoggedIn={isLoggedIn} remoteProject={remoteProject} currentView={currentView} loading={loading}></TitleBar>
+          <TitleBar
+            canCheckInAll={canCheckInAll}
+            currentView={currentView}
+            isLoggedIn={isLoggedIn}
+            loading={loading}
+            onCheckInAll={onCheckInAll}
+            onResourceAction={onResourceActionFilter}
+            parentResource={teiDoc}
+            remoteProject={remoteProject}
+          ></TitleBar>
           { this.renderToolbar() }
           <main>
               { this.renderResourceTable() }

--- a/src/render/css/TitleBar.css
+++ b/src/render/css/TitleBar.css
@@ -1,16 +1,25 @@
 #TitleBar {
     background: #43639D;
     height: 50px;
+    padding: 0 16px 0 0;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#TitleBar .title-bar-left {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
 }
 
 #TitleBar .home-icon {
-    margin-top: -5px;
     color: white;
 }
 
 #TitleBar .breadcrumbs {
     display: inline-block;
-    margin-top: 10px;
     color: white;
 }
 


### PR DESCRIPTION
## In this PR

- Add a "check in all" button
   - Only enabled on local, project root, in remote projects, when there are some documents in the index (i.e. not checked in yet, or checked out)
   - When clicked, set checking in state to true, and set all the local manifest resource IDs (`localResources`) as the resources to be checked in
   - When checking in via this mode, only show document count, not a table with each document and its status listed

## Notes

- Let me know if it should actually include the table of documents in the check in screen. I figure it's better without it for performance reasons.
- Like normal checkin, this could fail if any of the local resources can't be checked in for one reason or another. Not sure if there's a way to change that without backend changes, since i think it's a single API call
- Eventually, `TitleBar.renderVersionControl` should also include the "checked out by X" status indicator and, on a document, the quick "check in"/"check out" buttons—[see designs](https://www.figma.com/design/TXluhCbyELt247nifYChmU/FairCopy-Desktop?node-id=43-1712&t=zMi1JikC1NJFrTQ8-4). I figure this is the right place for "Check in all," but didn't implement the other stuff yet in the interest of time.