### PR TITLE
Allow draft and publishing documents (#627)

### DIFF
--- a/src/main-process/FairCopyApplication.js
+++ b/src/main-process/FairCopyApplication.js
@@ -164,6 +164,11 @@ class FairCopyApplication {
       this.fairCopySession.checkOut(userID, serverURL, projectID, resourceIDs)
     })
 
+    ipcMain.on('publish', (event, teiDoc) => {
+      this.sendToMainWindow('publishingResourceStarted')
+      this.fairCopySession.publish(teiDoc)
+    })
+
     ipcMain.on('requestSaveConfig', (event,fairCopyConfig,lastAction) => { this.fairCopySession.saveFairCopyConfig(fairCopyConfig,lastAction) })    
     ipcMain.on('checkInConfig', (event,fairCopyConfig,firstAction) => { this.fairCopySession.checkInConfig(fairCopyConfig,firstAction) })        
     ipcMain.on('checkOutConfig', (event) => { this.fairCopySession.checkOutConfig() })        

--- a/src/main-process/FairCopySession.js
+++ b/src/main-process/FairCopySession.js
@@ -272,7 +272,7 @@ class FairCopySession {
         this.requestResourceView()
     }
 
-    requestResourceView() {
+    requestResourceView(published) {
         const {currentView} = this.resourceViews
         const resourceView = this.resourceViews[currentView]
         const { indexParentID, currentPage, rowsPerPage } = resourceView
@@ -280,7 +280,7 @@ class FairCopySession {
 
         if( currentView === 'remote' ) {
             // request resource data from server
-            this.remoteProject.requestResourceView(resourceView)
+            this.remoteProject.requestResourceView(resourceView, published)
         } else {
             // respond right away from project store
             resourceView.parentEntry = indexParentID ? localResources[indexParentID] : null
@@ -329,7 +329,7 @@ class FairCopySession {
         }
     }
 
-    sendResourceViewUpdate(resourceView, remoteResources) {
+    sendResourceViewUpdate(resourceView, remoteResources, published) {
         const { resources: localResources } = this.projectStore.manifestData
         const { indexParentID, rowsPerPage, currentPage, totalRows } = resourceView
 
@@ -342,13 +342,26 @@ class FairCopySession {
             return localResources[resourceEntry.id] ? localResources[resourceEntry.id] : resourceEntry
         })
 
+        // at project root, map resource statuses to resources by guid
+        if (!resourceView.parentEntry && Object.hasOwn(resourceView, "statuses")) {
+            // get each status from resourceView.statuses into resourceIndex
+            const statusByGuid = Object.fromEntries(
+                resourceView.statuses.map(status => [status.resource_guid, status])
+            );
+            resourceIndex.forEach(resource => {
+                const { id } = resource;
+                if (id && Object.hasOwn(statusByGuid, id)) {
+                    resource.status = statusByGuid[id]
+                }
+            });
+        }
         // don't let currentPage be > page count 
         let pageCount = Math.ceil(totalRows/rowsPerPage)
         pageCount = pageCount === 0 ? 1 : pageCount
         resourceView.currentPage = currentPage > pageCount ? pageCount : currentPage
         
         this.resourceViews.remote = resourceView
-        this.fairCopyApplication.sendToAllWindows('resourceViewUpdate', { resourceViews: this.resourceViews, resourceIndex })
+        this.fairCopyApplication.sendToAllWindows('resourceViewUpdate', { resourceViews: this.resourceViews, resourceIndex, published })
     }
     
     searchProject(searchQuery) {
@@ -518,6 +531,10 @@ class FairCopySession {
 
     checkOut(userID, serverURL, projectID, resourceEntries) {
         this.projectStore.checkOut(userID, serverURL, projectID, resourceEntries)
+    }
+
+    publish(teiDoc) {
+        this.remoteProject.publish(teiDoc)
     }
 
     saveFairCopyConfig(fairCopyConfig, lastAction) {

--- a/src/main-process/RemoteProject.js
+++ b/src/main-process/RemoteProject.js
@@ -39,8 +39,8 @@ class RemoteProject {
                     break
                 case 'resource-view-update':
                     {
-                        const { resourceView, remoteResources } = msg
-                        this.fairCopySession.sendResourceViewUpdate(resourceView,remoteResources)
+                        const { resourceView, remoteResources, published } = msg
+                        this.fairCopySession.sendResourceViewUpdate(resourceView,remoteResources,published)
                     }
                     break    
                 case 'id-map-update': 
@@ -69,10 +69,10 @@ class RemoteProject {
                 break
                 case 'resources-updated':
                 {
-                    const { resources } = msg
+                    const { resources, published } = msg
                     // TODO determine which resources need to be updated 
                     // TODO what does this have to do with delete again?
-                    this.fairCopySession.requestResourceView()
+                    this.fairCopySession.requestResourceView(published)
                 }
                 break
                 default:
@@ -99,8 +99,8 @@ class RemoteProject {
         this.remoteProjectWorker.postMessage({ messageType: 'get-resource', resourceID, xmlID })
     }
 
-    requestResourceView(resourceView) {
-        this.remoteProjectWorker.postMessage({ messageType: 'request-view', resourceView })
+    requestResourceView(resourceView, published) {
+        this.remoteProjectWorker.postMessage({ messageType: 'request-view', resourceView, published })
     }
 
     checkInConfig(config, firstAction) {
@@ -109,6 +109,10 @@ class RemoteProject {
 
     checkOutConfig() {
         this.remoteProjectWorker.postMessage({ messageType: 'checkout-config' })
+    }
+
+    publish(teiDoc) {
+        this.remoteProjectWorker.postMessage({ messageType: 'publish', teiDoc })
     }
 }
 

--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -120,6 +120,7 @@ export default class MainWindow extends Component {
       leftPaneWidth: initialLeftPaneWidth,
       rightPaneWidth: initialRightPaneWidth,
       migratingResources: new Set(),
+      publishingResources: false,
     };
   }
 
@@ -200,9 +201,16 @@ export default class MainWindow extends Component {
     const {
       resourceViews: nextResourceViews,
       resourceIndex: nextResourceIndex,
+      published
     } = resourceData;
     const { currentView: nextCurrentView } = nextResourceViews;
     const nextResourceView = nextResourceViews[nextCurrentView];
+
+    // set publishingResources false if we got here from publish response
+    let publishingResourcesState = {};
+    if (published) {
+      publishingResourcesState = { publishingResources: false };
+    }
 
     // if the indexParentID or the currentView changed, clear checkmarks
     if (
@@ -213,12 +221,14 @@ export default class MainWindow extends Component {
       this.setState({
         ...this.state,
         ...checkmarkState,
+        ...publishingResourcesState,
         resourceViews: nextResourceViews,
         resourceIndex: nextResourceIndex,
       });
     } else {
       this.setState({
         ...this.state,
+        ...publishingResourcesState,
         resourceViews: nextResourceViews,
         resourceIndex: nextResourceIndex,
       });
@@ -257,6 +267,20 @@ export default class MainWindow extends Component {
     }));
   };
 
+  onPublishResource = (e) => {
+    this.setState((prevState) => ({
+      ...prevState,
+      publishingResources: true,
+    }));
+  }
+
+  onCompletePublishResource = (e) => {
+    this.setState((prevState) => ({
+      ...prevState,
+      publishingResources: false,
+    }));
+  }
+
   onResourceContentUpdated = (e, resourceUpdate) => {
     const { fairCopyProject } = this.props;
     fairCopyProject.notifyListeners("resourceContentUpdated", resourceUpdate);
@@ -294,6 +318,10 @@ export default class MainWindow extends Component {
     );
     fairCopy.ipcRegisterCallback("updateProjectInfo", this.onUpdateProjectInfo);
     fairCopy.ipcRegisterCallback("localResources", this.onLocalResources);
+    fairCopy.ipcRegisterCallback(
+      "publishingResourceStarted",
+      this.onPublishResource
+    );
   }
 
   componentWillUnmount() {
@@ -312,6 +340,14 @@ export default class MainWindow extends Component {
     );
     fairCopy.ipcRemoveListener("updateProjectInfo", this.onUpdateProjectInfo);
     fairCopy.ipcRemoveListener("localResources", this.onLocalResources);
+    fairCopy.ipcRemoveListener(
+      "resourceMigrationStarted",
+      this.onMigrateResource
+    );
+    fairCopy.ipcRemoveListener(
+      "publishingResourceStarted",
+      this.onPublishResource
+    );
   }
 
   refreshWindow() {
@@ -1077,6 +1113,7 @@ export default class MainWindow extends Component {
       allResourcesCheckmarked,
       resourceCheckmarks,
       migratingResources,
+      publishingResources,
     } = this.state;
     const { currentView } = resourceViews;
     const resourceView = resourceViews[currentView];
@@ -1107,6 +1144,7 @@ export default class MainWindow extends Component {
               resourceIndex={resourceIndex}
               fairCopyProject={fairCopyProject}
               panelWidth={rightPaneWidth}
+              publishingResources={publishingResources}
             ></ResourceBrowser>
         )}
         {this.renderEditors()}

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -1,15 +1,18 @@
 import React, { Component } from 'react';
-import { Button, Card, InputAdornment, IconButton, TableContainer, TableSortLabel, Table, Input, TableHead, TableRow, TableCell, TableBody, TablePagination, Tooltip, Checkbox, Typography, CardContent } from '@material-ui/core';
+import { Button, Card, Chip, InputAdornment, IconButton, TableContainer, TableSortLabel, Table, Input, TableHead, TableRow, TableCell, TableBody, TablePagination, Tooltip, Checkbox, Typography, CardContent, withStyles } from '@material-ui/core';
+import { Autorenew, Edit, Publish } from '@material-ui/icons';
 import TitleBar from '../TitleBar'
 import { debounce } from "debounce";
 
 import { getResourceIcon, getActionIcon, getResourceIconLabel } from '../../../model/resource-icon';
 import { isEntryEditable, isCheckedOutRemote } from '../../../model/FairCopyProject'
-import { canCheckOut, canCreate, canDelete } from '../../../model/permissions'
+import { canCheckOut, canCreate, canDelete, isAdmin } from '../../../model/permissions'
 import { ellipsis } from '../../../model/ellipsis'
 
 const idealNameLength = 35
 const idealPanelWidth = 1172
+
+const fairCopy = window.fairCopy
 
 export default class ResourceBrowser extends Component {
 
@@ -159,10 +162,11 @@ export default class ResourceBrowser extends Component {
   }
 
   renderToolbar() {
-    const { onEditResource, teiDoc, onImportResource, onEditTEIDoc, currentView, resourceCheckmarks, fairCopyProject } = this.props
+    const { onEditResource, teiDoc, onImportResource, onEditTEIDoc, currentView, resourceCheckmarks, fairCopyProject, publishingResources, resourceView } = this.props
     const { remote: remoteProject, permissions } = fairCopyProject
     const createAllowed = remoteProject ? canCreate(permissions) : true
     const canPreview = !fairCopyProject.remote || (fairCopyProject.remote && fairCopyProject.isLoggedIn())
+    const { loading } = resourceView;
 
     const buttonProps = {
       className: 'toolbar-button',
@@ -173,7 +177,17 @@ export default class ResourceBrowser extends Component {
     const onImportXML = () => { onImportResource('xml') }
     const onImportIIIF = () => { onImportResource('iiif') }
     const onPreviewResource = () => { fairCopyProject.previewResource(teiDoc) }
+    const onPublishResource = () => { fairCopy.ipcSend('publish', teiDoc) }
     const actionsEnabled = Object.values(resourceCheckmarks).find( c => !!c )
+    const atRemoteDoc = remoteProject && currentView === 'remote' && teiDoc
+    const canPublish = teiDoc?.status?.is_draft;
+    let publishTooltip = "Publish";
+    if (!canPublish) {
+      publishTooltip = "Document must have a draft checked in to publish";
+    }
+    const docActionType = teiDoc?.lastAction?.action_type;
+    const datePublished = docActionType === 'publish' ? new Date(teiDoc.lastAction.created_at).toDateString() : null;
+    const dateCheckedIn = ['update', 'create'].includes(docActionType) ? new Date(teiDoc.lastAction.created_at).toDateString() : null;    
 
     return (
       <div className="toolbar-container">
@@ -191,8 +205,42 @@ export default class ResourceBrowser extends Component {
                   </IconButton>
                 </Tooltip>
               }
+              {atRemoteDoc &&
+                <>
+                  {teiDoc.status?.is_published && (
+                    <Tooltip title={datePublished ? `Last published: ${datePublished}` : "Published"} arrow>
+                      <StyledChip label="Published" icon={<i className="fa fa-file-circle-check"></i>} size="small" color="primary" />
+                    </Tooltip>
+                  )}
+                  {teiDoc.status?.is_draft && (
+                    <Tooltip title={dateCheckedIn ? `Draft checked in: ${dateCheckedIn}` : "Draft"} arrow>
+                      <StyledChip label="Draft" icon={<Edit />} size="small" color="secondary" />
+                    </Tooltip>
+                  )}
+                  {teiDoc.status?.is_processing && (
+                    <Tooltip title="Document is currently being processed" arrow>
+                      <StyledChip label="Processing" icon={<Autorenew />} size="small" color="default" />
+                    </Tooltip>
+                  )}
+                </>
+              }
             </div>
             <div className="doc-header-right">
+              {atRemoteDoc && isAdmin(permissions) &&
+                <Tooltip title={publishTooltip} arrow>
+                  <span>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      disabled={!canPublish || loading || publishingResources}
+                      onClick={onPublishResource}
+                      startIcon={<Publish />}
+                    >
+                      Publish
+                    </Button>
+                  </span>
+                </Tooltip>
+              }
               <Tooltip title="Preview Published Document">
                 <span className="iconbutton-wrapper">
                   <IconButton
@@ -259,6 +307,7 @@ export default class ResourceBrowser extends Component {
     const { onResourceAction, fairCopyProject, resourceView, panelWidth, resourceIndex, currentView, resourceCheckmarks, allResourcesCheckmarked, teiDoc } = this.props
     const { remote: remoteProject, userID } = fairCopyProject
     const { currentPage, rowsPerPage, totalRows, orderBy, order } = resourceView
+    const atRemoteRoot = remoteProject && currentView !== 'home' && !teiDoc
 
     const onOpen = (resourceID) => {
       const resource = resourceIndex.find(resourceEntry => resourceEntry.id === resourceID )
@@ -346,10 +395,24 @@ export default class ResourceBrowser extends Component {
           <TableCell {...cellProps} >
             <Typography title={localID} className={textClass}>{displayLocalID}</Typography>
           </TableCell>
-          { remoteProject && 
+          { remoteProject && !teiDoc &&
           <TableCell {...cellProps} >
             <Typography className={textClass}>{lastModified}</Typography>
-          </TableCell>        
+          </TableCell>
+          }
+          { atRemoteRoot &&
+            <>
+              <TableCell {...cellProps} align="center" >
+                {resource.status?.is_draft && (
+                    <Edit aria-label="Draft" />
+                )}
+              </TableCell>
+              <TableCell {...cellProps} align="center" >
+                {resource.status?.is_published && (
+                    <i aria-label="Published" className="fa fa-file-circle-check"></i>
+                )}
+              </TableCell>
+            </>
           }
         </TableRow>
       )
@@ -373,7 +436,9 @@ export default class ResourceBrowser extends Component {
                           { teiDoc && <TableCell>Type</TableCell> }
                           { this.renderSortableHeaderCell('name','Name',orderBy,order) }
                           { this.renderSortableHeaderCell('localID','ID',orderBy,order) }
-                          { remoteProject && <TableCell>Last Modified</TableCell> }
+                          { remoteProject && !teiDoc && <TableCell>Last Modified</TableCell> }
+                          { atRemoteRoot && <TableCell>Draft</TableCell> }
+                          { atRemoteRoot && <TableCell>Published</TableCell> }
                       </TableRow>
                   </TableHead>
                   <TableBody>
@@ -451,3 +516,20 @@ export default class ResourceBrowser extends Component {
   }
 
 }
+
+const StyledChip = withStyles((theme) => ({
+  root: {
+    paddingLeft: 4,
+    paddingRight: 4,
+  },
+  colorPrimary: {
+    backgroundColor: theme.palette.success.dark,
+  },
+  colorSecondary: {
+    backgroundColor: theme.palette.info.dark,
+  },
+  iconColorPrimary: {
+    marginLeft: 6,
+    marginTop: 4,
+  }
+}))(React.forwardRef((props, ref) => <Chip {...props} ref={ref} />))

--- a/src/render/model/cloud-api/resources.js
+++ b/src/render/model/cloud-api/resources.js
@@ -69,10 +69,55 @@ export async function getResourceAsync( userID, serverURL, authToken, resourceID
 }
 
 function createResourceEntry(resourceData) { 
-    const { resource_guid: id, name, local_id: localID, parent_guid: parentResource, resource_type: type, git_head_revision: gitHeadRevision, last_action: lastAction } = resourceData
+    const { resource_guid: id, name, local_id: localID, parent_guid: parentResource, resource_type: type, git_head_revision: gitHeadRevision, last_action: lastAction, id: remoteID } = resourceData
     return {
-        id, name, localID, parentResource, type, gitHeadRevision, lastAction,
+        id, name, localID, parentResource, type, gitHeadRevision, lastAction, remoteID,
         local: false,
         deleted: false
     }   
+}
+
+export function getResourceStatus(userID, serverURL, authToken, remoteID, onSuccess, onFail) {
+    // get statuses for resources at the project root
+    const getStatusURL = `${serverURL}/api/resource_status/${remoteID}`
+    axios.get(getStatusURL, authConfig(authToken)).then(
+        (okResponse) => {
+            const { resource_status } = okResponse.data
+            onSuccess(resource_status)
+        },
+        standardErrorHandler(userID, serverURL, onFail)
+    )
+}
+
+export function getResourceStatuses(userID, serverURL, authToken, projectID, currentPage, rowsPerPage, nameFilter, order, orderBy, onSuccess, onFail) {
+    // get statuses for resources at the project root
+    const getStatusesURL = `${serverURL}/api/resource_status/search`
+
+    // set pagination, filter to TEI documents at the project root
+    const data = {
+        per_page: rowsPerPage,
+        page: currentPage || 1,
+        filters: [
+            { 'attribute_name': 'project_id', 'operator': 'equal', 'value': projectID },
+            { 'attribute_name': 'resource_type', 'operator': 'equal', 'value': 'teidoc' },
+        ]
+    }
+
+    // optional search/sort
+    if (nameFilter) {
+        data.search = nameFilter
+    }
+    if (order && orderBy) {
+        const sortBy = orderBy === 'localID' ? 'local_id' : orderBy   
+        data.sort_by = sortBy
+        data.sort_direction = order
+    }
+
+    axios.post(getStatusesURL, data, authConfig(authToken)).then(
+        (okResponse) => {
+            const { resource_statuses } = okResponse.data
+            onSuccess(resource_statuses)
+        },
+        standardErrorHandler(userID, serverURL, onFail)
+    )
 }

--- a/src/render/model/cloud-api/tei-documents.js
+++ b/src/render/model/cloud-api/tei-documents.js
@@ -1,0 +1,29 @@
+import axios from 'axios';
+
+import { authConfig } from './auth'
+import { standardErrorHandler } from './error-handler';
+
+export function getTeiDocument(userID, serverURL, authToken, projectID, localID, onSuccess, onFail) {
+    const getURL = `${serverURL}/api/tei_documents/${projectID}/${localID}`
+
+    axios.get(getURL, authConfig(authToken)).then(
+        (okResponse) => {
+            const { tei_document } = okResponse.data
+            onSuccess(tei_document)
+        },
+        standardErrorHandler(userID, serverURL, onFail)
+    )
+}
+
+
+export function publishTeiDocument(userID, serverURL, authToken, projectID, localID, onSuccess, onFail) {
+    const publishURL = `${serverURL}/api/tei_documents/publish/${projectID}/${localID}`
+
+    axios.post(publishURL, {}, authConfig(authToken)).then(
+        (okResponse) => {
+            const { tei_document } = okResponse.data
+            onSuccess(tei_document)
+        },
+        standardErrorHandler(userID, serverURL, onFail)
+    )
+}

--- a/src/render/workers/remote-project-worker.js
+++ b/src/render/workers/remote-project-worker.js
@@ -1,9 +1,10 @@
-import { getResource, getResources } from "../model/cloud-api/resources"
+import { getResource, getResources, getResourceStatus, getResourceStatuses } from "../model/cloud-api/resources"
 import { getProject } from "../model/cloud-api/projects"
 import { getAuthToken } from '../model/cloud-api/auth'
 import { getIDMap } from "../model/cloud-api/id-map"
 import { connectCable } from "../model/cloud-api/activity-cable"
 import { getConfig, initConfig, checkInConfig, checkOutConfig } from "../model/cloud-api/config"
+import { getTeiDocument, publishTeiDocument } from "../model/cloud-api/tei-documents"
 
 function updateIDMap( userID, serverURL, authToken, projectID, postMessage) {
     getIDMap( userID, serverURL, authToken, projectID, (idMapData) => {
@@ -13,19 +14,39 @@ function updateIDMap( userID, serverURL, authToken, projectID, postMessage) {
     })
 }
 
-function updateResourceView( userID, serverURL, projectID, resourceView, authToken, postMessage ) {
+function updateResourceView( userID, serverURL, projectID, resourceView, published, authToken, postMessage ) {
     if( authToken ) {
         const { currentPage, rowsPerPage, nameFilter, order, orderBy, indexParentID } = resourceView
         getResources( userID, serverURL, authToken, projectID, indexParentID, currentPage, rowsPerPage, nameFilter, order, orderBy, (resourceData) => {
             const { parentEntry, remoteResources, totalRows } = resourceData
-            resourceView.parentEntry = parentEntry
+            // ensure lastAction is preserved after retrieving remote parent entry
+            resourceView.parentEntry = parentEntry ? {
+                ...parentEntry,
+                lastAction: parentEntry?.lastAction || resourceView.parentEntry?.lastAction
+            } : parentEntry
             resourceView.totalRows = totalRows
             resourceView.loading = false
-            postMessage({ messageType: 'resource-view-update', resourceView, remoteResources })
-        }, 
+            // update resource view with remote resources and their statuses
+            if (parentEntry) {
+                // inside a TEI document, get parent document's draft/published/processing status
+                const { localID } = parentEntry
+                getTeiDocument(userID, serverURL, authToken, projectID, localID, (teiDocData) => {
+                    resourceView.parentEntry.status = teiDocData
+                    postMessage({ messageType: 'resource-view-update', resourceView, remoteResources, published })
+                },
+                (error) => console.log(error))
+            } else {
+                // at the remote project root, get all document statuses
+                getResourceStatuses(userID, serverURL, authToken, projectID, currentPage, rowsPerPage, nameFilter, order, orderBy, (statusData) => {
+                    resourceView.statuses = statusData
+                    postMessage({ messageType: 'resource-view-update', resourceView, remoteResources, published })
+                },
+                (error) => console.log(error))
+            }
+        },
         (error) => {
             console.log(error)
-        })                 
+        })
     } else {
         // user is not logged in, remote list is empty
         const emptyView = { indexParentID: null,
@@ -37,6 +58,17 @@ function updateResourceView( userID, serverURL, projectID, resourceView, authTok
         } 
         postMessage({ messageType: 'resource-view-update', resourceView: emptyView, remoteResources: [] })
     }
+}
+
+function onPublishTeiDocument(userID, serverURL, projectID, teiDoc, authToken, postMessage) {
+    const { localID } = teiDoc
+    publishTeiDocument(userID, serverURL, authToken, projectID, localID, () => {
+        // refresh the current view's resources to show updated document's "published/processing" status
+        postMessage({ messageType: 'resources-updated', published: true })
+    },
+    (error) => {
+        console.log(error)
+    })
 }
 
 function updateProjectInfo( userID, serverURL, authToken, projectID, postMessage) {
@@ -163,8 +195,12 @@ export function remoteProject( msg, workerMethods, workerData ) {
             checkOutFairCopyConfig( userID, serverURL, projectID, authToken, postMessage )
             break
         case 'request-view':
-            const { resourceView } = msg     
-            updateResourceView( userID, serverURL, projectID, resourceView, authToken, postMessage )
+            const { resourceView, published } = msg     
+            updateResourceView( userID, serverURL, projectID, resourceView, published, authToken, postMessage )
+            break
+        case 'publish':
+            const { teiDoc } = msg
+            onPublishTeiDocument(userID, serverURL, projectID, teiDoc, authToken, postMessage)
             break
         case 'close':
             close()


### PR DESCRIPTION
### In this PR

- Add API calls to FCC2 exclusive `tei_documents` and `tei_documents/publish`, as well as `resource_status` and `resource_statuses/search`.
- Show draft/published status of documents in the resource browser list. (mapped by guid)
- Show the draft/published/processing status of the current document when browsing resources inside of a document.
- Add a "Publish" button, enabled when a document can be published (i.e. has a draft).

### Questions/notes

- This is a breaking change as it relies on FCC2 for the backend for remote projects. In particular, the `resource_statuses` call will prevent loading the document list, and the Publish button will call `/publish` which won't work if that endpoint doesn't exist.
    - This means that existing remote projects will cause errors unless they are migrated to FCC2 and their URL updated.
    - Is integration with FCC2 something we should make optional, and if so, how so?
- It's a bit hacky, but I pass a `published` argument all the way down the "request resources" call tree, which only gets set `true` after a successful publish endpoint call. The idea here is to instantly update with "processing" or "published" status, before turning off the loading state, with as few code changes as possible (i.e. not writing an entire new resource view update routine). It feels a bit strange to have this usually-false boolean tacked on to all these calls, but seemed like the simplest solution.