### PR TITLE
Use status search endpoint for resources (#632)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "windows": {
               "runtimeExecutable": "${workspaceFolder}/node_modules/@electron-forge/cli/script/vscode.cmd"
             },            
-            "env": { "FAIRCOPY_DEBUG_MODE": "true", "FAIRCOPY_DEV_VERSION": "1.2.1-dev.2" },
+            "env": { "FAIRCOPY_DEBUG_MODE": "true", "FAIRCOPY_DEV_VERSION": "1.3.0-dev.3" },
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faircopy",
-  "version": "1.3.0-dev.2",
+  "version": "1.3.0-dev.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faircopy",
-      "version": "1.3.0-dev.2",
+      "version": "1.3.0-dev.3",
       "dependencies": {
         "@codemirror/lang-css": "^6.2.1",
         "@cu-mkp/editioncrafter": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faircopy",
   "productName": "FairCopy",
-  "version": "1.3.0-dev.2",
+  "version": "1.3.0-dev.3",
   "description": "A word processor for the humanities scholar.",
   "main": "./.webpack/main",
   "private": true,

--- a/src/main-process/FairCopySession.js
+++ b/src/main-process/FairCopySession.js
@@ -342,19 +342,6 @@ class FairCopySession {
             return localResources[resourceEntry.id] ? localResources[resourceEntry.id] : resourceEntry
         })
 
-        // at project root, map resource statuses to resources by guid
-        if (!resourceView.parentEntry && Object.hasOwn(resourceView, "statuses")) {
-            // get each status from resourceView.statuses into resourceIndex
-            const statusByGuid = Object.fromEntries(
-                resourceView.statuses.map(status => [status.resource_guid, status])
-            );
-            resourceIndex.forEach(resource => {
-                const { id } = resource;
-                if (id && Object.hasOwn(statusByGuid, id)) {
-                    resource.status = statusByGuid[id]
-                }
-            });
-        }
         // don't let currentPage be > page count 
         let pageCount = Math.ceil(totalRows/rowsPerPage)
         pageCount = pageCount === 0 ? 1 : pageCount

--- a/src/render/model/cloud-api/resources.js
+++ b/src/render/model/cloud-api/resources.js
@@ -5,28 +5,40 @@ import { standardErrorHandler } from './error-handler';
 
 const maxResourcesPerPage = 9999
 
-export function getResources(userID, serverURL, authToken, projectID, indexParentID, currentPage, rowsPerPage, nameFilter, order, orderBy, onSuccess, onFail) {
-    const parentQ = indexParentID ? `/${indexParentID}` : '/null'
-    const nameFilterQ = nameFilter ? `&search=${nameFilter}` : ''
-    const currentPageQ = currentPage ? `&page=${currentPage}` : '&page=1'
-    const rowsPerPageQ = `per_page=${rowsPerPage}`
-    let sortByQ, sortDirectionQ
-    if( order && orderBy ) {
-        const sortBy = orderBy === 'localID' ? 'local_id' : orderBy   
-        sortByQ = `&sort_by=${sortBy}`
-        sortDirectionQ = `&sort_direction=${order}`     
-    } else {
-        sortByQ = ''
-        sortDirectionQ = ''
-    }
-    const getProjectsURL = `${serverURL}/api/resources/by_project_by_parent/${projectID}${parentQ}?${rowsPerPageQ}${currentPageQ}${nameFilterQ}${sortByQ}${sortDirectionQ}`
+export function getResources(userID, serverURL, authToken, projectID, parentEntry, currentPage, rowsPerPage, nameFilter, order, orderBy, onSuccess, onFail) {
+    // get resource list using the status endpoint
+    const getStatusesURL = `${serverURL}/api/resource_status/search`
+    const parentID = parentEntry?.remoteID
 
-    axios.get(getProjectsURL,authConfig(authToken)).then(
+    // set pagination params, filters
+    const data = {
+        per_page: rowsPerPage,
+        page: currentPage || 1,
+        filters: [
+            { 'attribute_name': 'project_id', 'operator': 'equal', 'value': projectID },
+            // in document, get only children; at project root, get only TEI docs
+            parentID
+                ? { 'attribute_name': 'parent_id', 'operator': 'equal', 'value': parentID }
+                : { 'attribute_name': 'resource_type', 'operator': 'equal', 'value': 'teidoc' },
+        ]
+    }
+
+    // optional search/sort
+    if (nameFilter) {
+        data.search = nameFilter
+    }
+    if (order && orderBy) {
+        const sortBy = orderBy === 'localID' ? 'local_id' : orderBy   
+        data.sort_by = sortBy
+        data.sort_direction = order
+    }
+
+    axios.post(getStatusesURL, data, authConfig(authToken)).then(
         (okResponse) => {
-            const { resources, list } = okResponse.data
+            const { resource_statuses: resources, list } = okResponse.data
             const remoteResources = resources.map( resourceObj => createResourceEntry(resourceObj) )
             const totalRows = list.count
-            const parentEntry = indexParentID !== null && resources.length > 0 ? createResourceEntry( resources[0].parent_resource ) : null
+            const parentEntry = parentID && resources.length > 0 && resources[0].parent ? createResourceEntry( resources[0].parent ) : null
             onSuccess({ parentEntry, totalRows, remoteResources })
         },
         standardErrorHandler(userID, serverURL, onFail)
@@ -48,9 +60,9 @@ export function getResource( userID, serverURL, authToken, resourceID, onSuccess
     )
 }
 
-export async function getResourcesAsync( userID, serverURL, authToken, projectID, resourceID, currentPage, rowsPerPage=maxResourcesPerPage, nameFilter=null, order=null, orderBy=null ) {
+export async function getResourcesAsync( userID, serverURL, authToken, projectID, parentEntry, currentPage, rowsPerPage=maxResourcesPerPage, nameFilter=null, order=null, orderBy=null ) {
     return new Promise( ( resolve, reject ) => {
-        getResources( userID, serverURL, authToken, projectID, resourceID, currentPage, rowsPerPage, nameFilter, order, orderBy, (remoteResources) => {
+        getResources( userID, serverURL, authToken, projectID, parentEntry, currentPage, rowsPerPage, nameFilter, order, orderBy, (remoteResources) => {
             resolve(remoteResources)
         }, (errorMessage) => {
             reject(new Error(errorMessage))
@@ -69,55 +81,11 @@ export async function getResourceAsync( userID, serverURL, authToken, resourceID
 }
 
 function createResourceEntry(resourceData) { 
-    const { resource_guid: id, name, local_id: localID, parent_guid: parentResource, resource_type: type, git_head_revision: gitHeadRevision, last_action: lastAction, id: remoteID } = resourceData
+    const { resource_guid: id, name, local_id: localID, parent_guid: parentResource, resource_type: type, git_head_revision: gitHeadRevision, last_action: lastAction, id: remoteID, is_draft, is_published } = resourceData
     return {
         id, name, localID, parentResource, type, gitHeadRevision, lastAction, remoteID,
+        status: { is_draft, is_published },
         local: false,
         deleted: false
     }   
-}
-
-export function getResourceStatus(userID, serverURL, authToken, remoteID, onSuccess, onFail) {
-    // get statuses for resources at the project root
-    const getStatusURL = `${serverURL}/api/resource_status/${remoteID}`
-    axios.get(getStatusURL, authConfig(authToken)).then(
-        (okResponse) => {
-            const { resource_status } = okResponse.data
-            onSuccess(resource_status)
-        },
-        standardErrorHandler(userID, serverURL, onFail)
-    )
-}
-
-export function getResourceStatuses(userID, serverURL, authToken, projectID, currentPage, rowsPerPage, nameFilter, order, orderBy, onSuccess, onFail) {
-    // get statuses for resources at the project root
-    const getStatusesURL = `${serverURL}/api/resource_status/search`
-
-    // set pagination, filter to TEI documents at the project root
-    const data = {
-        per_page: rowsPerPage,
-        page: currentPage || 1,
-        filters: [
-            { 'attribute_name': 'project_id', 'operator': 'equal', 'value': projectID },
-            { 'attribute_name': 'resource_type', 'operator': 'equal', 'value': 'teidoc' },
-        ]
-    }
-
-    // optional search/sort
-    if (nameFilter) {
-        data.search = nameFilter
-    }
-    if (order && orderBy) {
-        const sortBy = orderBy === 'localID' ? 'local_id' : orderBy   
-        data.sort_by = sortBy
-        data.sort_direction = order
-    }
-
-    axios.post(getStatusesURL, data, authConfig(authToken)).then(
-        (okResponse) => {
-            const { resource_statuses } = okResponse.data
-            onSuccess(resource_statuses)
-        },
-        standardErrorHandler(userID, serverURL, onFail)
-    )
 }

--- a/src/render/workers/project-archive-worker.js
+++ b/src/render/workers/project-archive-worker.js
@@ -85,7 +85,7 @@ async function checkOut( userID, serverURL, projectID, resourceEntries, zip, pos
     for( const resourceEntry of resourceEntries ) {
         const { id: resourceID, type } = resourceEntry
         if( type === 'teidoc' ) {
-            const resourceData = await getResourcesAsync( userID, serverURL, authToken, projectID, resourceID, 1)
+            const resourceData = await getResourcesAsync( userID, serverURL, authToken, projectID, resourceEntry, 1)
             for( const resource of resourceData.remoteResources ) {
                 if( resource.type !== 'header' ) resourceIDs.push(resource.id)
             }
@@ -141,7 +141,7 @@ async function prepareResourceExport( resourceEntry, projectData, zip ) {
                         }
                     }
                 } else {
-                    const resourceData = await getResourcesAsync( userID, serverURL, authToken, projectID, resourceEntry.id, 1)
+                    const resourceData = await getResourcesAsync( userID, serverURL, authToken, projectID, resourceEntry, 1)
                     const { remoteResources } = resourceData
 
                     for( const remoteEntry of remoteResources ) {

--- a/src/render/workers/remote-project-worker.js
+++ b/src/render/workers/remote-project-worker.js
@@ -1,4 +1,4 @@
-import { getResource, getResources, getResourceStatus, getResourceStatuses } from "../model/cloud-api/resources"
+import { getResource, getResources } from "../model/cloud-api/resources"
 import { getProject } from "../model/cloud-api/projects"
 import { getAuthToken } from '../model/cloud-api/auth'
 import { getIDMap } from "../model/cloud-api/id-map"
@@ -16,8 +16,8 @@ function updateIDMap( userID, serverURL, authToken, projectID, postMessage) {
 
 function updateResourceView( userID, serverURL, projectID, resourceView, published, authToken, postMessage ) {
     if( authToken ) {
-        const { currentPage, rowsPerPage, nameFilter, order, orderBy, indexParentID } = resourceView
-        getResources( userID, serverURL, authToken, projectID, indexParentID, currentPage, rowsPerPage, nameFilter, order, orderBy, (resourceData) => {
+        const { currentPage, rowsPerPage, nameFilter, order, orderBy, parentEntry: viewParentEntry } = resourceView
+        getResources( userID, serverURL, authToken, projectID, viewParentEntry, currentPage, rowsPerPage, nameFilter, order, orderBy, (resourceData) => {
             const { parentEntry, remoteResources, totalRows } = resourceData
             // ensure lastAction is preserved after retrieving remote parent entry
             resourceView.parentEntry = parentEntry ? {
@@ -26,7 +26,7 @@ function updateResourceView( userID, serverURL, projectID, resourceView, publish
             } : parentEntry
             resourceView.totalRows = totalRows
             resourceView.loading = false
-            // update resource view with remote resources and their statuses
+            // update resource view with remote resources
             if (parentEntry) {
                 // inside a TEI document, get parent document's draft/published/processing status
                 const { localID } = parentEntry
@@ -36,12 +36,8 @@ function updateResourceView( userID, serverURL, projectID, resourceView, publish
                 },
                 (error) => console.log(error))
             } else {
-                // at the remote project root, get all document statuses
-                getResourceStatuses(userID, serverURL, authToken, projectID, currentPage, rowsPerPage, nameFilter, order, orderBy, (statusData) => {
-                    resourceView.statuses = statusData
-                    postMessage({ messageType: 'resource-view-update', resourceView, remoteResources, published })
-                },
-                (error) => console.log(error))
+                // at the remote project root, update view
+                postMessage({ messageType: 'resource-view-update', resourceView, remoteResources, published })
             }
         },
         (error) => {


### PR DESCRIPTION
## In this PR

Resolve the slowdown for the Remote view (#632):
- Use the `/resource_status/search` endpoint to retrieve lists of documents at the project root, and resources inside of a TEI document
   - Integrate with existing search filtering, sorting, and pagination
   - Since that also populates draft/published statuses, remove special handling for mapping statuses by guid
   - Also remove now-unused `getResourceStatus` and `getResourceStatuses` functions
   - Update calls to `getResourcesAsync` to always include the parent entry, in order to pass TEI documents' remote ID (database ID from FCC2) to the filter
- Bump version to 1.3.0-dev.3