### PR TITLE
At project root, only allow importing TEI docs with headers (#631)

### DIFF
--- a/src/main-process/FairCopyApplication.js
+++ b/src/main-process/FairCopyApplication.js
@@ -181,8 +181,8 @@ class FairCopyApplication {
       }
     })
 
-    ipcMain.on('requestImport', (event,options) => { 
-      const paths = this.mainMenu.openImport()
+    ipcMain.on('requestImport', (event,options) => {
+      const paths = this.mainMenu.openImport(options.parentResourceID)
       if( paths ) {
         this.fairCopySession.importStart(paths,options)
       }

--- a/src/main-process/MainMenu.js
+++ b/src/main-process/MainMenu.js
@@ -29,10 +29,11 @@ class MainMenu {
         })
     }
 
-    openImport = () => {
+    openImport = (inDocument) => {
       return dialog.showOpenDialogSync( {
-        title: "Select text or xml files to import.",
-        properties: [ 'openFile', 'multiSelections' ]
+        title: `Select ${inDocument ? "text or " : ""}xml files to import.`,
+        properties: [ 'openFile', 'multiSelections' ],
+        filters: inDocument ? [] : [{ name: 'TEI XML files', extensions: ['xml'] }],
       })
     }
 

--- a/src/render/components/main-window/dialogs/ImportTextsDialog.jsx
+++ b/src/render/components/main-window/dialogs/ImportTextsDialog.jsx
@@ -98,12 +98,12 @@ export default class ImportTextsDialog extends Component {
         )
     }
 
-    render() {      
-        const { onClose } = this.props
+    render() {
+        const { onClose, parentResourceID } = this.props
     
         const onClickSelect = () => {
             const { lineBreakParsing, learnStructure, resourceType, replaceResource } = this.state
-            fairCopy.ipcSend('requestImport', {lineBreakParsing,learnStructure,resourceType,replaceResource})
+            fairCopy.ipcSend('requestImport', {lineBreakParsing,learnStructure,resourceType,replaceResource,parentResourceID})
             this.setState(this.initialState)
             onClose()
         }
@@ -121,12 +121,22 @@ export default class ImportTextsDialog extends Component {
                 aria-labelledby="import-texts-title"
                 aria-describedby="import-texts-description"
             >
-                <DialogTitle>Import Texts</DialogTitle>
+                <DialogTitle>{parentResourceID ? "Import Texts" : "Import TEI Documents"}</DialogTitle>
                 <DialogContent>
-                    <Typography>You can select plain text files (UTF-8 encoded) or XML files to import.</Typography>
-                    <Typography>XML files must contain one or more text or facsimile elements. XML elements that are not supported by FairCopy will be ignored, but their contents will be included.</Typography>
+                    <Typography>
+                        {parentResourceID
+                            ? "You can select plain text files (UTF-8 encoded) or XML files to import."
+                            : "Select TEI XML files to import."
+                        }
+                    </Typography>
+                    {parentResourceID
+                        ? <Typography>XML files must contain one or more text or facsimile elements.</Typography>
+                        : <Typography>XML files must contain a TEI header element, as well as one or more text or facsimile elements.</Typography>}
+                    <Typography>
+                        XML elements that are not supported by FairCopy will be ignored, but their contents will be included.
+                    </Typography>
                     <Typography component='h2' variant='h6'>Import Options</Typography>
-                    { this.renderLineBreakOptions() }
+                    { parentResourceID && this.renderLineBreakOptions() }
                     { this.renderLearnStructure() }
                     { this.renderReplaceResource() }
                 </DialogContent>

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -264,7 +264,9 @@ export default class ResourceBrowser extends Component {
             { currentView === 'home' && 
               <div className='inline-button-group'>
                 <Button color="primary" disabled={!createAllowed} onClick={onEditResource} {...buttonProps}>Add New</Button>
-                <Button color="primary" disabled={!createAllowed} onClick={onImportXML} {...buttonProps}>Import Texts</Button>
+                <Button color="primary" disabled={!createAllowed} onClick={onImportXML} {...buttonProps}>
+                  {teiDoc ? "Import Text" : "Import TEI"}
+                </Button>
                 <Button color="primary" disabled={!createAllowed} onClick={onImportIIIF} {...buttonProps}>Import IIIF</Button>
               </div>
             }

--- a/src/render/model/import-tei.js
+++ b/src/render/model/import-tei.js
@@ -46,8 +46,10 @@ function importFileResource(importData,parentEntry,fairCopyProject) {
     } else if( xmlExt ) {
         // if the file had a .xml extension but is invalid XML
         throw new Error('File contains invalid XML.')
-    } else {
+    } else if (parentEntry) {
         return importTxtResource(data, name, localID, existingParentID, fairCopyProject, options)
+    } else {
+        throw new Error('Only TEI document XML files may be imported to the project root.')
     }
 }
 
@@ -223,10 +225,12 @@ function importXMLResource(xmlDom, name, localID, idMap, parentEntry, existingPa
             const resource = createResource(resourceEl, childName, childLocalID, parentEntryID, fairCopyProject, fairCopyConfig, learnStructure)
             resources.push(resource)
         }
-    } else {
+    } else if (existingParentID) {
         // if there is no header only take the first resource, it gets the name and localID
         const resource = createResource(extractedResources.resources[0], name, localID, existingParentID, fairCopyProject, fairCopyConfig, learnStructure)
         resources.push(resource)
+    } else {
+        throw new Error('Document must contain a <teiHeader> element to be imported at the project root.')
     }
     
     // Things look OK, return these resources


### PR DESCRIPTION
## In this PR

- Only allow importing TEI documents, with `teiHeader`, at project root
   - Pass parent ID along to dialog box, in order to limit options if it's not present (i.e. hide line break options, update text)
   - Update `showOpenDialogSync` call to limit chosen files to `.xml` extension at project root
   - Throw errors during TEI parsing if somehow a non-XML file was still passed at project root, or the XML file does not contain a `teiHeader`