### PR TITLE
Truncate long document names in new TEI doc header bar; add tooltip with full name (#635)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "windows": {
               "runtimeExecutable": "${workspaceFolder}/node_modules/@electron-forge/cli/script/vscode.cmd"
             },            
-            "env": { "FAIRCOPY_DEBUG_MODE": "true", "FAIRCOPY_DEV_VERSION": "1.3.0-dev.3" },
+            "env": { "FAIRCOPY_DEBUG_MODE": "true", "FAIRCOPY_DEV_VERSION": "1.3.0-dev.4" },
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faircopy",
-  "version": "1.3.0-dev.3",
+  "version": "1.3.0-dev.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faircopy",
-      "version": "1.3.0-dev.3",
+      "version": "1.3.0-dev.4",
       "dependencies": {
         "@codemirror/lang-css": "^6.2.1",
         "@cu-mkp/editioncrafter": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faircopy",
   "productName": "FairCopy",
-  "version": "1.3.0-dev.3",
+  "version": "1.3.0-dev.4",
   "description": "A word processor for the humanities scholar.",
   "main": "./.webpack/main",
   "private": true,

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -11,6 +11,7 @@ import { ellipsis } from '../../../model/ellipsis'
 
 const idealNameLength = 35
 const idealPanelWidth = 1172
+const maxDocTitleLength = 64
 
 const fairCopy = window.fairCopy
 
@@ -194,7 +195,9 @@ export default class ResourceBrowser extends Component {
         { teiDoc &&
           <div className="doc-header">
             <div className="doc-header-left">
-              <Typography component="h2" variant="h6">{teiDoc.name}</Typography>
+              <Tooltip title={teiDoc.name}>
+                <Typography component="h2" variant="h6">{ellipsis(teiDoc.name, maxDocTitleLength)}</Typography>
+              </Tooltip>
               {currentView === 'home' && 
                 <Tooltip title="Edit Document Properties">
                   <IconButton


### PR DESCRIPTION
## In this PR

- Use `ellipsis` function to truncate long document names in the new TEI document header bar
- Truncate to 64 characters (will end up about the same width as breadcrumbs)
- Add tooltip so users can see the full name on mouseover