### PR TITLE
Batch check-ins by resource count (#637)

### DIFF
--- a/src/main-process/FairCopyApplication.js
+++ b/src/main-process/FairCopyApplication.js
@@ -156,8 +156,8 @@ class FairCopyApplication {
       this.fairCopySession.importEnd()
     })
 
-    ipcMain.on('checkIn', (event, userID, serverURL, projectID, checkInResources, message ) => { 
-      this.fairCopySession.checkIn(userID, serverURL, projectID, checkInResources, message)
+    ipcMain.on('checkIn', (event, userID, serverURL, projectID, resourceIDBatches, message ) => { 
+      this.fairCopySession.checkIn(userID, serverURL, projectID, resourceIDBatches, message)
     })
 
     ipcMain.on('checkOut', (event, userID, serverURL, projectID, resourceIDs ) => { 

--- a/src/main-process/FairCopySession.js
+++ b/src/main-process/FairCopySession.js
@@ -480,9 +480,9 @@ class FairCopySession {
         this.idMapAuthority.sendIDMapUpdate()
     }
 
-    checkIn(userID, serverURL, projectID, checkInResources, message) {
+    checkIn(userID, serverURL, projectID, resourceIDBatches, message) {
         const { resources } = this.projectStore.manifestData
-        const committedResources = []
+        const committedResourceBatches = []
 
         const createCommitEntry = ( resourceEntry ) => {
             const { id, local, deleted, name, localID, parentResource: parentID, type } = resourceEntry
@@ -498,22 +498,27 @@ class FairCopySession {
                 resourceType: type
             }
         }
-        
-        const homeParentID = this.resourceViews.home.indexParentID
-        for( const resourceID of checkInResources ) {
-            const resourceEntry = resources[resourceID]
-            // ignore resources that aren't in local manifest
-            if( resourceEntry ) {
-                const resourceCommitEntry = createCommitEntry(resourceEntry)
-                committedResources.push(resourceCommitEntry)
-            }
-            if( resourceID === homeParentID ) {
-                // if this got checked in, move to root
-                this.resourceViews.home.indexParentID = null
-            }
-        }
 
-        this.projectStore.checkIn(userID, serverURL, projectID, committedResources, message)
+        const homeParentID = this.resourceViews.home.indexParentID
+        resourceIDBatches.forEach((batch) => {
+            // convert each resource ID batch into an array of resources
+            const resourceBatch = []
+            for( const resourceID of batch ) {
+                const resourceEntry = resources[resourceID]
+                // ignore resources that aren't in local manifest
+                if( resourceEntry ) {
+                    const resourceCommitEntry = createCommitEntry(resourceEntry)
+                    resourceBatch.push(resourceCommitEntry)
+                }
+                if( resourceID === homeParentID ) {
+                    // if this got checked in, move to root
+                    this.resourceViews.home.indexParentID = null
+                }
+            }
+            committedResourceBatches.push(resourceBatch)
+        })
+
+        this.projectStore.checkIn(userID, serverURL, projectID, committedResourceBatches, message)
     }
 
     checkOut(userID, serverURL, projectID, resourceEntries) {

--- a/src/main-process/ProjectStore.js
+++ b/src/main-process/ProjectStore.js
@@ -375,8 +375,8 @@ class ProjectStore {
         this.saveManifest()
     }
 
-    checkIn(userID, serverURL, projectID, committedResources, message) {
-        this.projectArchiveWorker.postMessage({ messageType: 'check-in', userID, serverURL, projectID, committedResources, message })
+    checkIn(userID, serverURL, projectID, committedResourceBatches, message) {
+        this.projectArchiveWorker.postMessage({ messageType: 'check-in', userID, serverURL, projectID, committedResourceBatches, message })
     }
 
     checkOut(userID, serverURL, projectID, resourceEntries ) {

--- a/src/render/components/main-window/dialogs/CheckInDialog.jsx
+++ b/src/render/components/main-window/dialogs/CheckInDialog.jsx
@@ -12,6 +12,9 @@ const cellProps = {
     scope: "row"
 }
 
+// maximum number of resources per batch
+const batchSizeLimit = 50
+
 const fairCopy = window.fairCopy
 
 export default class CheckInDialog extends Component {
@@ -22,14 +25,21 @@ export default class CheckInDialog extends Component {
             message: "",
             committedResources: [],
             status: 'ready',
-            resourceStatus: null,
-            errorMessage: null
+            resourceStatus: {},
+            errorMessage: null,
+            resourcesToCommit: [],
+            batchesComplete: 0,
         }
         this.state = this.initialState
     }
 
     componentDidMount() {
         fairCopy.ipcRegisterCallback('checkInResults', this.onCheckInResults )
+        // perform resouce batching on mount
+        this.setState((prevState) => ({
+            ...prevState,
+            resourcesToCommit: this.getResourcesToCommit(),
+        }))
     }
 
     componentWillUnmount() {
@@ -38,50 +48,84 @@ export default class CheckInDialog extends Component {
 
     getResourcesToCommit() {
         const { checkInResources, localResources } = this.props
+
+        // group resources into batches of max size batchSizeLimit, without separating TEI docs
+        // from child resources.
+        // resourcesToCommit is a 2D array of batches.
         let resourcesToCommit = []
+        let currentBatch = []
+
         for( const resourceID of checkInResources ) {
             const resource = localResources[resourceID]
             // ignore resources that aren't checked out
-            if( resource ) {
-                const { id: resourceID, type: resourceType, deleted } = resource                
-                if( resourceType === 'teidoc' ) {
-                    // commit any checked out children, delete if parent is deleted
-                    for( const checkedOutResource of Object.values(localResources) ) {
-                        if( resourceID === checkedOutResource.parentResource ) {                            
-                            if( deleted ) checkedOutResource.deleted = true
-                            resourcesToCommit.push(checkedOutResource) 
-                        }
+            if (!resource) continue
+            
+            const { id, type, deleted } = resource
+
+            // ensure TEI docs are grouped with their child resources
+            let resourceGroup = [resource]
+
+            if( type === 'teidoc' ) {
+                // commit any checked out children, delete if parent is deleted
+                for( const checkedOutResource of Object.values(localResources) ) {
+                    if( id === checkedOutResource.parentResource ) {                            
+                        if( deleted ) checkedOutResource.deleted = true
+                        resourceGroup.push(checkedOutResource) 
                     }
                 }
-                resourcesToCommit.push(resource)    
             }
+
+            const batchSize = currentBatch.length
+
+            // prevent going over batchSizeLimit resources per batch (unless a single resource
+            // group goes over the limit, in which case currentBatch is empty)
+            if (batchSize !== 0 && batchSize + resourceGroup.length > batchSizeLimit) {
+                // push batch to queue, create new batch
+                resourcesToCommit.push(currentBatch)
+                currentBatch = []
+            }
+
+            // add all resources from resources group to current batch
+            currentBatch.push(...resourceGroup)
+        }
+        // push last batch if non-empty
+        if (currentBatch.length > 0) {
+            resourcesToCommit.push(currentBatch)
         }
         return resourcesToCommit
     }
 
     onCheckInResults = (event, checkInResult) => {
         const { resourceEntries, resourceStatus, error } = checkInResult
-        if( error ) {
-            this.setState({...this.state, committedResources: resourceEntries, resourceStatus, status: 'done', errorMessage: error })
-        } else {
-            this.setState({...this.state, committedResources: resourceEntries, resourceStatus, status: 'done', errorMessage: null })
-        }
+        this.setState((prevState) => {
+            // when we get new results message back, concat previous committed resources list with new one
+            const committedResources = prevState.committedResources.concat(resourceEntries)
+            // update number of batches complete to get status
+            const totalBatches = prevState.resourcesToCommit.length
+            const batchesComplete = prevState.batchesComplete + 1
+            return {
+                committedResources,
+                batchesComplete,
+                status: batchesComplete === totalBatches ? 'done' : 'loading',
+                resourceStatus: { ...prevState.resourceStatus, ...resourceStatus },
+                errorMessage: error || prevState.error || null
+            }
+        })
     }
 
     renderResourceTable() {
         const { fairCopyProject } = this.props
-        const { committedResources, resourceStatus, status } = this.state
-        const resourcesToCommit = this.getResourcesToCommit()
-        const responseReceived = status === 'done'
-        const resourceList = responseReceived ? committedResources : resourcesToCommit
-        const resources = resourceList.sort((a, b) => a.name.localeCompare(b.name))
-        
+        const { committedResources, resourceStatus, resourcesToCommit, status } = this.state
+        const allResourcesToCommit = resourcesToCommit.flat()
+        const committedDocuments = committedResources.filter((resource) => resource.type === 'teidoc')
+        const allDocuments = allResourcesToCommit.filter((resource) => resource.type === 'teidoc')
+        const responseReceived = ['loading', 'done'].includes(status)
+        const resources = responseReceived ? committedDocuments : allDocuments
+
         const resourceRows = []
         for( const resource of resources ) {
-            const { id: resourceID, type: resourceType, local, deleted, localID, name } = resource
-            // only display document entries
-            if( resourceType !== 'teidoc' ) continue
-            const resourceStatusCode = resourceStatus ? resourceStatus[resourceID] : null
+            const { id: resourceID, local, deleted, localID, name } = resource
+            const resourceStatusCode = Object.keys(resourceStatus).length ? resourceStatus[resourceID] : null
             const resourceStatusMessage = getResourceStatusMessage(resourceStatusCode)
             const editable = isEntryEditable(resource, fairCopyProject.userID)
             let { icon, label } = getActionIcon(responseReceived, local, editable )
@@ -109,7 +153,10 @@ export default class CheckInDialog extends Component {
             )            
         }
 
-        const caption = status === 'done' ? 'These documents have been processed.' : 'These documents are ready to be checked in.'
+        const totalDocuments = allDocuments.length
+        const caption = responseReceived
+            ? `${committedDocuments.length}/${totalDocuments} documents have been processed.`
+            : `${totalDocuments} documents are ready to be checked in.`
 
         return (
             <div>
@@ -133,16 +180,15 @@ export default class CheckInDialog extends Component {
         )
     }
 
-    onCheckIn = () => {              
+    onCheckIn = () => {
         const { fairCopyProject } = this.props
         const { userID, serverURL, projectID } = fairCopyProject
-        const { message } = this.state   
-        const resourcesToCommit = this.getResourcesToCommit()
+        const { message, resourcesToCommit } = this.state
 
         if( message.length > 0 ) {
-            const resourceIDs = resourcesToCommit.map( r => r.id )
-            this.setState({ ...this.state, status: 'loading' }) 
-            fairCopy.ipcSend('checkIn', userID, serverURL, projectID, resourceIDs, message )   
+            this.setState({ ...this.state, status: 'loading' })
+            const resourceIDBatches = resourcesToCommit.map((batch) => batch.map(r => r.id))
+            fairCopy.ipcSend('checkIn', userID, serverURL, projectID, resourceIDBatches, message)
         } else {
             this.setState({ ...this.state, errorMessage: "Please provide a commit message." })
         }
@@ -177,14 +223,13 @@ export default class CheckInDialog extends Component {
     }
 
     renderCheckInAll() {
-        const { committedResources, status } = this.state
-        const resourcesToCommit = this.getResourcesToCommit()
-        const responseReceived = status === 'done'
-        const resourceList = responseReceived ? committedResources : resourcesToCommit
-        const documentCount = resourceList.filter((resource) => resource.type === 'teidoc').length
-        const caption = status === 'done'
-            ? `${documentCount} documents have been processed.`
-            : `${documentCount} documents are ready to be checked in.`
+        const { committedResources, status, resourcesToCommit } = this.state
+        const allResourcesToCommit = resourcesToCommit.flat()
+        const committedDocumentCount = committedResources.filter((resource) => resource.type === 'teidoc').length
+        const totalDocuments = allResourcesToCommit.filter((resource) => resource.type === 'teidoc').length
+        const caption = ['loading', 'done'].includes(status)
+            ? `${committedDocumentCount}/${totalDocuments} documents have been processed.`
+            : `${totalDocuments} documents are ready to be checked in.`
         return (
             <Typography>{caption}</Typography>
         )

--- a/src/render/css/CheckInDialog.css
+++ b/src/render/css/CheckInDialog.css
@@ -11,3 +11,7 @@
 #CheckInDialog .error-message {
     color: red;
 }
+
+#CheckInDialog caption {
+    caption-side: top;
+}

--- a/src/render/model/cloud-api/resource-management.js
+++ b/src/render/model/cloud-api/resource-management.js
@@ -42,6 +42,35 @@ export function checkInResources(userID, serverURL, authToken, projectID, resour
     )
 }
 
+async function checkInResourcesAsync(userID, serverURL, authToken, projectID, resources, message) {
+    return new Promise((resolve, reject) => {
+        try {
+            checkInResources(userID, serverURL, authToken, projectID, resources, message, (resourceState) => {
+                resolve(resourceState)
+            }, (errorMessage, resourceState) => {
+                reject({ errorMessage, resourceState })
+            })
+        } catch (err) {
+            // catch errors not related to the request response hitting onFail
+            reject({ errorMessage: String(err), resourceState: [] });
+        }
+    })
+}
+
+export async function checkInResourceBatches(userID, serverURL, authToken, projectID, resourceBatches, message, onSuccess, onFail) {
+    // wait until each successful async checkin has completed to check in the next batch; call onSuccess or onFail for each
+    // successful or failed batch
+    for (let i = 0; i < resourceBatches.length; i++) {
+        const msg = i === 0 ? message : `${message} (${i})`;
+        try {
+            const resourceState = await checkInResourcesAsync(userID, serverURL, authToken, projectID, resourceBatches[i], msg)
+            onSuccess(resourceState)
+        } catch ({ errorMessage, resourceState }) {
+            onFail(errorMessage, resourceState)
+        }
+    }
+}
+
 export function checkOutResources(serverURL, authToken, projectID, resourceIDs) {
    
     const resourceObjs = resourceIDs.map( (resourceID) => {

--- a/src/render/model/cloud-api/resources.js
+++ b/src/render/model/cloud-api/resources.js
@@ -16,6 +16,7 @@ export function getResources(userID, serverURL, authToken, projectID, parentEntr
         page: currentPage || 1,
         filters: [
             { 'attribute_name': 'project_id', 'operator': 'equal', 'value': projectID },
+            { 'attribute_name': 'is_deleted', 'operator': 'equal', 'value': false },
             // in document, get only children; at project root, get only TEI docs
             parentID
                 ? { 'attribute_name': 'parent_id', 'operator': 'equal', 'value': parentID }

--- a/src/render/workers/project-archive-worker.js
+++ b/src/render/workers/project-archive-worker.js
@@ -1,5 +1,5 @@
 import { getAuthToken } from '../model/cloud-api/auth'
-import { checkInResources, checkOutResources } from '../model/cloud-api/resource-management'
+import { checkInResourceBatches, checkOutResources } from '../model/cloud-api/resource-management'
 import { getResourceAsync, getResourcesAsync } from "../model/cloud-api/resources"
 import { serializeResource } from "../model/serialize-xml"
 import { renderTEIDocument } from "../model/editioncrafter/render"
@@ -37,7 +37,7 @@ function addFile( localFilePath, resourceID, zip ) {
     zip.file(resourceID, buffer)
 }
 
-async function checkIn( userID, serverURL, projectID, committedResources, message, zip, postMessage ) {
+async function checkIn( userID, serverURL, projectID, committedResourceBatches, message, zip, postMessage ) {
     const authToken = getAuthToken( userID, serverURL )
 
     if( authToken ) {
@@ -62,17 +62,19 @@ async function checkIn( userID, serverURL, projectID, committedResources, messag
         }
     
         // add the content for each resource being added or updated
-        for( const committedResource of committedResources ) {
-            if( committedResource.action !== 'destroy' && committedResource.type !== 'teidoc' ) {
-                committedResource.content = await readUTF8(committedResource.id, zip)
-            } else {
-                committedResource.content = null
+        for( const batch of committedResourceBatches ) {
+            for( const committedResource of batch ) {
+                if( committedResource.action !== 'destroy' && committedResource.type !== 'teidoc' ) {
+                    committedResource.content = await readUTF8(committedResource.id, zip)
+                } else {
+                    committedResource.content = null
+                }
             }
         }
-      
-        checkInResources(userID, serverURL, authToken, projectID, committedResources, message, onSuccess, onFail)    
+
+        await checkInResourceBatches(userID, serverURL, authToken, projectID, committedResourceBatches, message, onSuccess, onFail)    
     } else {
-        postMessage({ messageType: 'check-in-results', resourceIDs: [], error: "User not logged in." })
+        postMessage({ messageType: 'check-in-results', resourceStatus: [], error: "User not logged in." })
     }
 }
 
@@ -420,8 +422,8 @@ export function projectArchive( msg, workerMethods, workerData ) {
             break                   
         case 'check-in': 
             {
-                const { userID, serverURL, projectID, committedResources, message } = msg
-                checkIn( userID, serverURL, projectID, committedResources, message, zip, postMessage )
+                const { userID, serverURL, projectID, committedResourceBatches, message } = msg
+                checkIn( userID, serverURL, projectID, committedResourceBatches, message, zip, postMessage )
             }    
             break  
         case 'check-out': 


### PR DESCRIPTION
### In this PR

- Fix a bug where deleted remote entries would show up in the remote list

Per #637:
- Batch check-ins (both normal and "check in all") by max 50 resources per check-in
   - Send them in series with async/await; update the UI on each completed response
   - Ensure TEI documents are checked in at the same time as all of their child resources
     (Allow a single TEI document with more than 50 resources to be checked in in its own batch)
   - Move the document count caption to the top of the table when checking in, as it updates live
   - Only perform `getResourcesToCommit` once, on mount of the checkin dialog

### Notes

I wanted to get the simplest version out ASAP, but I did note there was some confusion about the word "processed" in the status message after a check in response. This is because we now also have a "processing" status for documents when they are generating a draft or published version on the server.

I think that word choice was deliberate to say "check ins for all these documents have been attempted, but some may have had errors and were not checked in successfully." So if we want to address the confusion long term, we should probably keep track of how many documents were checked in and how many errored and display those separately. But probably unnecessary for an MVP; you'll be able to tell how many errored regardless.