### PR TITLE
Only enable "Publish" button on checked-in documents (#639)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "windows": {
               "runtimeExecutable": "${workspaceFolder}/node_modules/@electron-forge/cli/script/vscode.cmd"
             },            
-            "env": { "FAIRCOPY_DEBUG_MODE": "true", "FAIRCOPY_DEV_VERSION": "1.3.0-dev.4" },
+            "env": { "FAIRCOPY_DEBUG_MODE": "true", "FAIRCOPY_DEV_VERSION": "1.3.0-dev.5" },
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faircopy",
-  "version": "1.3.0-dev.4",
+  "version": "1.3.0-dev.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faircopy",
-      "version": "1.3.0-dev.4",
+      "version": "1.3.0-dev.5",
       "dependencies": {
         "@codemirror/lang-css": "^6.2.1",
         "@cu-mkp/editioncrafter": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faircopy",
   "productName": "FairCopy",
-  "version": "1.3.0-dev.4",
+  "version": "1.3.0-dev.5",
   "description": "A word processor for the humanities scholar.",
   "main": "./.webpack/main",
   "private": true,

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -164,7 +164,7 @@ export default class ResourceBrowser extends Component {
 
   renderToolbar() {
     const { onEditResource, teiDoc, onImportResource, onEditTEIDoc, currentView, resourceCheckmarks, fairCopyProject, publishingResources, resourceView } = this.props
-    const { remote: remoteProject, permissions } = fairCopyProject
+    const { remote: remoteProject, permissions, userID } = fairCopyProject
     const createAllowed = remoteProject ? canCreate(permissions) : true
     const canPreview = !fairCopyProject.remote || (fairCopyProject.remote && fairCopyProject.isLoggedIn())
     const { loading } = resourceView;
@@ -181,10 +181,12 @@ export default class ResourceBrowser extends Component {
     const onPublishResource = () => { fairCopy.ipcSend('publish', teiDoc) }
     const actionsEnabled = Object.values(resourceCheckmarks).find( c => !!c )
     const atRemoteDoc = remoteProject && currentView === 'remote' && teiDoc
-    const canPublish = teiDoc?.status?.is_draft;
-    let publishTooltip = "Publish";
+    const editable = teiDoc && isEntryEditable(teiDoc, userID)
+    const checkedOut = teiDoc && (editable || isCheckedOutRemote(teiDoc, userID))
+    const canPublish = teiDoc?.status?.is_draft && !checkedOut
+    let publishTooltip = "Publish"
     if (!canPublish) {
-      publishTooltip = "Document must have a draft checked in to publish";
+      publishTooltip = checkedOut ? "Document must be checked in to publish" : "Document must have a draft checked in to publish"
     }
     const docActionType = teiDoc?.lastAction?.action_type;
     const datePublished = docActionType === 'publish' ? new Date(teiDoc.lastAction.created_at).toDateString() : null;


### PR DESCRIPTION
### In this PR

- Bump version to dev.5

per #639:
- Disable the "Publish" button if there is no draft, OR if the document is checked out, by you or another user
- Update the tooltip to reflect this change
