### PR TITLE
Disable publish during processing (#644)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "windows": {
               "runtimeExecutable": "${workspaceFolder}/node_modules/@electron-forge/cli/script/vscode.cmd"
             },            
-            "env": { "FAIRCOPY_DEBUG_MODE": "true", "FAIRCOPY_DEV_VERSION": "1.3.0-dev.5" },
+            "env": { "FAIRCOPY_DEBUG_MODE": "true", "FAIRCOPY_DEV_VERSION": "1.3.0-dev.6" },
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faircopy",
-  "version": "1.3.0-dev.5",
+  "version": "1.3.0-dev.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faircopy",
-      "version": "1.3.0-dev.5",
+      "version": "1.3.0-dev.6",
       "dependencies": {
         "@codemirror/lang-css": "^6.2.1",
         "@cu-mkp/editioncrafter": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faircopy",
   "productName": "FairCopy",
-  "version": "1.3.0-dev.5",
+  "version": "1.3.0-dev.6",
   "description": "A word processor for the humanities scholar.",
   "main": "./.webpack/main",
   "private": true,

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -207,7 +207,13 @@ export default class ResourceBrowser extends Component {
     const canPublish = teiDoc?.status?.is_draft && !checkedOut && !teiDoc.status.is_processing
     let publishTooltip = "Publish"
     if (!canPublish) {
-      publishTooltip = checkedOut ? "Document must be checked in to publish" : "Document must have a draft checked in to publish"
+      if (!teiDoc?.status?.is_draft) {
+        publishTooltip = "Document must have a draft checked in to publish"
+      } else if (checkedOut) {
+        publishTooltip = "Document must be checked in to publish"
+      } else {
+        publishTooltip = "Document must finish processing before it can be published"
+      }
     }
     const docActionType = teiDoc?.lastAction?.action_type;
     const datePublished = docActionType === 'publish' ? new Date(teiDoc.lastAction.created_at).toDateString() : null;

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -204,7 +204,7 @@ export default class ResourceBrowser extends Component {
     const atRemoteDoc = remoteProject && currentView === 'remote' && teiDoc
     const editable = teiDoc && isEntryEditable(teiDoc, userID)
     const checkedOut = teiDoc && (editable || isCheckedOutRemote(teiDoc, userID))
-    const canPublish = teiDoc?.status?.is_draft && !checkedOut
+    const canPublish = teiDoc?.status?.is_draft && !checkedOut && !teiDoc.status.is_processing
     let publishTooltip = "Publish"
     if (!canPublish) {
       publishTooltip = checkedOut ? "Document must be checked in to publish" : "Document must have a draft checked in to publish"


### PR DESCRIPTION
## In this PR

Per #644:
- Disable "Publish" button when a document is processing, update disabled tooltip in that case