### PR TITLE
Bug fix for issue #499

### DIFF
--- a/src/render/components/main-window/tei-editor/ParameterDrawer.jsx
+++ b/src/render/components/main-window/tei-editor/ParameterDrawer.jsx
@@ -407,6 +407,7 @@ export default class ParameterDrawer extends Component {
     const { elements } = teiSchema;
     const configElements = fairCopyConfig.elements;
     const name = element.type.name;
+    const isMark = name.startsWith("mark")
     const elementID = name.startsWith("mark")
       ? name.slice("mark".length)
       : name.endsWith("X")
@@ -424,7 +425,8 @@ export default class ParameterDrawer extends Component {
     };
 
     const onAddToSchema = () => {
-      const elementMenu = teiSchema.getElementMenu(elementSpec.pmType)[0];
+      const elementType = isMark ? "mark" : elementSpec.pmType
+      const elementMenu = teiSchema.getElementMenu(elementType)[0];
       addElementToSchema(elementID, elementMenu, fairCopyConfig);
       saveConfig(fairCopyConfig);
       teiDocument.refreshView();


### PR DESCRIPTION
When an element is missing from the project schema, it is marked as a validation error. These errors can be resolved by clicking on the "Add Element to Schema" button in the Parameter Drawer. However, when a mark element was added in this way, it was getting added to the Structure Palette. This fix makes them appear on the marks menu instead.