### PR TITLE
Copying surfaces doesn't copy all of the data

### DIFF
--- a/src/render/model/FacsDocument.js
+++ b/src/render/model/FacsDocument.js
@@ -184,8 +184,18 @@ export default class FacsDocument {
 
         const nextZones = []
         for( const zone of zones ) {
-            const { id, ulx, uly, lrx, lry, note } = zone
-            nextZones.push({ id, ulx, uly, lrx, lry, note })
+            const { id : nextZoneID, ana, note } = zone
+            const nextZone = { id: nextZoneID, ana, note }
+            if( zone.points ) {
+                nextZone.points = zone.points
+            } else {
+                const { ulx, uly, lrx, lry } = zone
+                nextZone.ulx = ulx
+                nextZone.uly = uly
+                nextZone.lrx = lrx
+                nextZone.lry = lry
+            }
+            nextZones.push(nextZone)
         }
 
         const dupeSurface = {


### PR DESCRIPTION
This PR fixes an issue where copying zones between facs resources is not copying all of the data. There is a new ana attribute field and the structure of the data for zone shapes has changed. The copy function is updated by this PR to keep it current with these changes.