### PR TITLE
Fix issues related to protocol permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faircopy",
-  "version": "1.3.0-dev.9",
+  "version": "1.3.0-dev.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faircopy",
-      "version": "1.3.0-dev.9",
+      "version": "1.3.0-dev.10",
       "dependencies": {
         "@codemirror/lang-css": "^6.2.1",
         "@cu-mkp/editioncrafter": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17612,11 +17612,12 @@
       }
     },
     "node_modules/macos-alias": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.11.tgz",
-      "integrity": "sha512-zIUs3+qpml+w3wiRuADutd7XIO8UABqksot10Utl/tji4UxZzLG4fWDC+yJZoO8/Ehg5RqsvSRE/6TS5AEOeWw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.12.tgz",
+      "integrity": "sha512-yiLHa7cfJcGRFq4FrR4tMlpNHb4Vy4mWnpajlSSIFM5k4Lv8/7BbbDLzCAVogWNl0LlLhizRp1drXv0hK9h0Yw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faircopy",
   "productName": "FairCopy",
-  "version": "1.3.0-dev.9",
+  "version": "1.3.0-dev.10",
   "description": "A word processor for the humanities scholar.",
   "main": "./.webpack/main",
   "private": true,

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,8 @@ if (require('electron-squirrel-startup')) {
   app.quit();
 }
 
-protocol.registerSchemesAsPrivileged([
+const schemes = [
+  { scheme: 'ws', privileges: { bypassCSP: true } }, 
   { scheme: 'https', privileges: { bypassCSP: true } }, 
   { scheme: 'ec', privileges: { 
       bypassCSP: true,
@@ -17,7 +18,14 @@ protocol.registerSchemesAsPrivileged([
       supportFetchAPI: true, 
     } 
   }
-])
+]
+
+// Allow HTTP protocol connections in dev mode only
+if(!app.isPackaged) {
+  schemes.push({ scheme: 'http', privileges: { bypassCSP: true } })
+}
+
+protocol.registerSchemesAsPrivileged(schemes)
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.


### PR DESCRIPTION
This PR adjusts the allowed web protocol schemes depending on whether the app is in development mode or packaged for distribution. In development mode, it now allows HTTP so that we can connect to localhost builds of FairCopy Server.

Also, noticed that this was also the fix for the broken web socket connections we were seeing. Added ws protocol to the scheme list and web sockets work again. This may uncover regressions that have come up since WS has been broken.


