### PR TITLE
Published document link

### DIFF
--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -286,10 +286,10 @@ export default class ResourceBrowser extends Component {
                   </IconButton>
                 </span>
               </Tooltip>
-              { remoteProject && <Tooltip title="Link to Published Document">
+              { remoteProject && <Tooltip title="Copy IIIF Manifest Link to Clipboard">
                 <span className="iconbutton-wrapper">
                   <IconButton
-                    aria-label="Link to Published Document"
+                    aria-label="Copy IIIF Manifest Link to Clipboard"
                     disabled={!teiDoc.status?.is_published}
                     onClick={onCopyPublishedLink}
                     className='toolbar-button'

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -286,7 +286,7 @@ export default class ResourceBrowser extends Component {
                   </IconButton>
                 </span>
               </Tooltip>
-              <Tooltip title="Link to Published Document">
+              { remoteProject && <Tooltip title="Link to Published Document">
                 <span className="iconbutton-wrapper">
                   <IconButton
                     aria-label="Link to Published Document"
@@ -297,7 +297,7 @@ export default class ResourceBrowser extends Component {
                     <i className='fa fa-link fa-md' />
                   </IconButton>
                 </span>
-              </Tooltip>
+              </Tooltip> }
             </div>
           </div>
         }

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -200,6 +200,7 @@ export default class ResourceBrowser extends Component {
     const onImportIIIF = () => { onImportResource('iiif') }
     const onPreviewResource = () => { fairCopyProject.previewResource(teiDoc) }
     const onPublishResource = () => { fairCopy.ipcSend('publish', teiDoc) }
+    const onCopyPublishedLink= () => { fairCopyProject.copyPublishedLinkToClipboard(teiDoc) }
     const actionsEnabled = Object.values(resourceCheckmarks).find( c => !!c )
     const atRemoteDoc = remoteProject && currentView === 'remote' && teiDoc
     const editable = teiDoc && isEntryEditable(teiDoc, userID)
@@ -282,6 +283,18 @@ export default class ResourceBrowser extends Component {
                     className='toolbar-button'
                   >
                     <i className='fa fa-eye fa-md' />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              <Tooltip title="Link to Published Document">
+                <span className="iconbutton-wrapper">
+                  <IconButton
+                    aria-label="Link to Published Document"
+                    disabled={!teiDoc.status?.is_published}
+                    onClick={onCopyPublishedLink}
+                    className='toolbar-button'
+                  >
+                    <i className='fa fa-link fa-md' />
                   </IconButton>
                 </span>
               </Tooltip>

--- a/src/render/model/FairCopyProject.js
+++ b/src/render/model/FairCopyProject.js
@@ -318,7 +318,7 @@ export default class FairCopyProject {
 
     copyPublishedLinkToClipboard = (teiDocument) => {
         // example: http://localhost:3789/public/2/tei_documents/fa25_adriaenssens_j/iiif"
-        const publishedURL = `${this.serverURL}/public/${this.projectID}/tei_documents/${teiDocument.resourceEntry.localID}/iiif`
+        const publishedURL = `${this.serverURL}/public/${this.projectID}/tei_documents/${teiDocument.localID}/iiif`
         fairCopy.copyToClipBoard(publishedURL)
     }
 

--- a/src/render/model/FairCopyProject.js
+++ b/src/render/model/FairCopyProject.js
@@ -316,6 +316,12 @@ export default class FairCopyProject {
         this.orphanedResources = []
     }
 
+    copyPublishedLinkToClipboard = (teiDocument) => {
+        // example: http://localhost:3789/public/2/tei_documents/fa25_adriaenssens_j/iiif"
+        const publishedURL = `${this.serverURL}/public/${this.projectID}/tei_documents/${teiDocument.resourceEntry.localID}/iiif`
+        fairCopy.copyToClipBoard(publishedURL)
+    }
+
     duplicateDocuments = (localResources) => {
         // duplicate resources and their children with new XML IDs and uuids
         const teiDocs = localResources.filter((r) => r.type === 'teidoc')


### PR DESCRIPTION
Add a link button next to the preview button on the TEI Document Page. Clicking on this button copies a link to the published document to the clipboard. The button is disabled if the document has not been published and hidden if this is not a remote project. The link points to the IIIF Manifest endpoint, not an EC viewer.