### PR TITLE
Move appdmg to optionalDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,6 @@
         "@electron-forge/publisher-github": "^7.9.0",
         "@electron/fuses": "^1.8.0",
         "@vercel/webpack-asset-relocator-loader": "1.7.3",
-        "appdmg": "^0.6.6",
         "babel-loader": "^9.1.3",
         "css-loader": "^6.0.0",
         "dotenv": "^16.3.1",
@@ -73,6 +72,9 @@
         "node-loader": "^2.0.0",
         "prosemirror-dev-tools": "4.1.0",
         "style-loader": "^3.0.0"
+      },
+      "optionalDependencies": {
+        "appdmg": "^0.6.6"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -8145,7 +8147,7 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.6.tgz",
       "integrity": "sha512-GRmFKlCG+PWbcYF4LUNonTYmy0GjguDy6Jh9WP8mpd0T6j80XIJyXBiWlD0U+MLNhqV9Nhx49Gl9GpVToulpLg==",
-      "dev": true,
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -8437,7 +8439,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "dev": true
+      "optional": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -8912,7 +8914,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
       "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "to-data-view": "^1.1.0"
       }
@@ -9085,7 +9087,7 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
       "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "stream-buffers": "~2.2.0"
       }
@@ -11362,7 +11364,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
       "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "bplist-creator": "~0.0.3",
         "macos-alias": "~0.2.5",
@@ -11993,7 +11995,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
       "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
-      "dev": true
+      "optional": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -12032,7 +12034,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -12900,7 +12902,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^4.0.0",
@@ -12918,7 +12920,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -12934,7 +12936,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -12943,7 +12945,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -12952,7 +12954,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -12964,7 +12966,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12973,7 +12975,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -13563,7 +13565,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
       "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "imul": "^1.0.0"
       }
@@ -13789,7 +13791,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.2.1.tgz",
       "integrity": "sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "random-path": "^0.1.0"
       }
@@ -13798,8 +13800,8 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.3.1.tgz",
       "integrity": "sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==",
-      "dev": true,
       "hasInstallScript": true,
+      "optional": true,
       "os": [
         "!win32"
       ],
@@ -13885,7 +13887,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-property": "^1.0.2"
       }
@@ -13894,7 +13896,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-property": "^1.0.0"
       }
@@ -13997,7 +13999,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -14788,7 +14790,7 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
       "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
-      "dev": true,
+      "optional": true,
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -14847,7 +14849,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
       "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15250,13 +15252,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
       "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
-      "dev": true
+      "optional": true
     },
     "node_modules/is-my-json-valid": {
       "version": "2.20.6",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
       "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
@@ -15331,7 +15333,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "dev": true
+      "optional": true
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -15393,7 +15395,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17600,9 +17602,9 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.12.tgz",
       "integrity": "sha512-yiLHa7cfJcGRFq4FrR4tMlpNHb4Vy4mWnpajlSSIFM5k4Lv8/7BbbDLzCAVogWNl0LlLhizRp1drXv0hK9h0Yw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -19081,7 +19083,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.2.0.tgz",
       "integrity": "sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "encode-utf8": "^1.0.3",
         "fmix": "^0.1.0",
@@ -19112,7 +19114,7 @@
       "version": "2.22.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
       "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
-      "dev": true
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -19158,7 +19160,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -19332,7 +19334,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "path-key": "^2.0.0"
       },
@@ -19344,7 +19346,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -19689,7 +19691,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -19836,7 +19838,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
       "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "color-convert": "~0.5.0"
       }
@@ -19845,7 +19847,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
       "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
-      "dev": true
+      "optional": true
     },
     "node_modules/parse-entities": {
       "version": "2.0.0",
@@ -21858,7 +21860,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -21953,7 +21955,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz",
       "integrity": "sha512-4jY0yoEaQ5v9StCl5kZbNIQlg1QheIDBrdkDn53EynpPb9FgO6//p3X/tgMnrC45XN6QZCzU1Xz/+pSSsJBpRw==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "base32-encode": "^0.1.0 || ^1.0.0",
         "murmur-32": "^0.1.0 || ^0.2.0"
@@ -23059,7 +23061,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -24243,7 +24245,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 0.10.0"
       }
@@ -24473,7 +24475,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25295,7 +25297,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
       "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "unorm": "^1.4.1"
       },
@@ -25307,7 +25309,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
       "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
-      "dev": true
+      "optional": true
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -25853,7 +25855,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
       "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 0.4.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7137,16 +7137,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@types/react-dom": {
-      "version": "17.0.25",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
-      "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/react": "^17"
-      }
-    },
     "node_modules/@types/react-redux": {
       "version": "7.1.33",
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.33.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@electron-forge/publisher-github": "^7.9.0",
     "@electron/fuses": "^1.8.0",
     "@vercel/webpack-asset-relocator-loader": "1.7.3",
-    "appdmg": "^0.6.6",
     "babel-loader": "^9.1.3",
     "css-loader": "^6.0.0",
     "dotenv": "^16.3.1",
@@ -43,6 +42,9 @@
     "node-loader": "^2.0.0",
     "prosemirror-dev-tools": "4.1.0",
     "style-loader": "^3.0.0"
+  },
+  "optionalDependencies": {
+    "appdmg": "^0.6.6"
   },
   "dependencies": {
     "@codemirror/lang-css": "^6.2.1",


### PR DESCRIPTION
Found that when doing `npm install` on Windows, the install was failing on appdmg, which is needed to build ARM DMGs. By making this an optional dependency, it will skip installation of this module on Windows but not on Mac. 

Note; I was only able to test this on Mac Intel, it would be good to give it a spin on Apple chipset and make sure DMGs still build properly.
