### PR TITLE
Update agent function to pass project ID parameter

### DIFF
--- a/src/main-process/FairCopyApplication.js
+++ b/src/main-process/FairCopyApplication.js
@@ -174,8 +174,8 @@ class FairCopyApplication {
       this.fairCopySession.publishCss()
     })
 
-    ipcMain.on('performAgent', (event, fileContents, docID) => {
-      this.fairCopySession.performAgent(fileContents, docID)
+    ipcMain.on('runAgent', (event, fileContents, docID) => {
+      this.fairCopySession.runAgent(fileContents, docID)
     })
 
     ipcMain.on('requestSaveConfig', (event, fairCopyConfig, lastAction) => { this.fairCopySession.saveFairCopyConfig(fairCopyConfig, lastAction) })

--- a/src/main-process/FairCopyApplication.js
+++ b/src/main-process/FairCopyApplication.js
@@ -174,8 +174,8 @@ class FairCopyApplication {
       this.fairCopySession.publishCss()
     })
 
-    ipcMain.on('performNER', (event, fileContents, docID) => {
-      this.fairCopySession.performNER(fileContents, docID)
+    ipcMain.on('performAgent', (event, fileContents, docID) => {
+      this.fairCopySession.performAgent(fileContents, docID)
     })
 
     ipcMain.on('requestSaveConfig', (event, fairCopyConfig, lastAction) => { this.fairCopySession.saveFairCopyConfig(fairCopyConfig, lastAction) })

--- a/src/main-process/FairCopySession.js
+++ b/src/main-process/FairCopySession.js
@@ -544,8 +544,8 @@ class FairCopySession {
         this.remoteProject.publishCss()
     }
 
-    performNER(fileContents, docID) {
-        this.remoteProject.performNER(fileContents, docID)
+    performAgent(fileContents, docID) {
+        this.remoteProject.performAgent(fileContents, docID)
     }
 
     saveFairCopyConfig(fairCopyConfig, lastAction) {

--- a/src/main-process/FairCopySession.js
+++ b/src/main-process/FairCopySession.js
@@ -544,8 +544,8 @@ class FairCopySession {
         this.remoteProject.publishCss()
     }
 
-    performAgent(fileContents, docID) {
-        this.remoteProject.performAgent(fileContents, docID)
+    runAgent(fileContents, docID) {
+        this.remoteProject.runAgent(fileContents, docID)
     }
 
     saveFairCopyConfig(fairCopyConfig, lastAction) {

--- a/src/main-process/RemoteProject.js
+++ b/src/main-process/RemoteProject.js
@@ -113,14 +113,14 @@ class RemoteProject {
                     {
                         const { xml, docID } = msg
                         const { fairCopyApplication } = this.fairCopySession
-                        fairCopyApplication.sendToMainWindow('performAgentResult', { xml, docID })
+                        fairCopyApplication.sendToMainWindow('runAgentResult', { xml, docID })
                     }
                     break
                 case 'agent-failed':
                     {
                         const { error } = msg
                         const { fairCopyApplication } = this.fairCopySession
-                        fairCopyApplication.sendToMainWindow('performAgentFailed', { error })
+                        fairCopyApplication.sendToMainWindow('runAgentFailed', { error })
                     }
                     break
                 default:
@@ -175,7 +175,7 @@ class RemoteProject {
         this.remoteProjectWorker.postMessage({ messageType: 'publish-css' })
     }
 
-    performAgent(fileContents, docID) {
+    runAgent(fileContents, docID) {
         this.remoteProjectWorker.postMessage({ messageType: 'perform-ner', fileContents, docID })
     }
 }

--- a/src/main-process/RemoteProject.js
+++ b/src/main-process/RemoteProject.js
@@ -109,18 +109,18 @@ class RemoteProject {
                         }
                     }
                     break
-                case 'ner-updated':
+                case 'agent-updated':
                     {
                         const { xml, docID } = msg
                         const { fairCopyApplication } = this.fairCopySession
-                        fairCopyApplication.sendToMainWindow('performNERResult', { xml, docID })
+                        fairCopyApplication.sendToMainWindow('performAgentResult', { xml, docID })
                     }
                     break
-                case 'ner-failed':
+                case 'agent-failed':
                     {
                         const { error } = msg
                         const { fairCopyApplication } = this.fairCopySession
-                        fairCopyApplication.sendToMainWindow('performNERFailed', { error })
+                        fairCopyApplication.sendToMainWindow('performAgentFailed', { error })
                     }
                     break
                 default:
@@ -175,7 +175,7 @@ class RemoteProject {
         this.remoteProjectWorker.postMessage({ messageType: 'publish-css' })
     }
 
-    performNER(fileContents, docID) {
+    performAgent(fileContents, docID) {
         this.remoteProjectWorker.postMessage({ messageType: 'perform-ner', fileContents, docID })
     }
 }

--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -388,8 +388,8 @@ export default class MainWindow extends Component {
     )
     fairCopy.ipcRegisterCallback('checkInStarted', this.onCheckInStarted)
     fairCopy.ipcRegisterCallback('checkInResults', this.onCheckInResults)
-    fairCopy.ipcRegisterCallback('performNERResult', this.onPerformNERResults)
-    fairCopy.ipcRegisterCallback('performNERFailed', this.onNERFailed)
+    fairCopy.ipcRegisterCallback('performAgentResult', this.onPerformAgentResults)
+    fairCopy.ipcRegisterCallback('performAgentFailed', this.onAgentFailed)
   }
 
   componentWillUnmount() {
@@ -423,8 +423,8 @@ export default class MainWindow extends Component {
     )
     fairCopy.ipcRemoveListener('checkInStarted', this.onCheckInStarted)
     fairCopy.ipcRemoveListener('checkInResults', this.onCheckInResults)
-    fairCopy.ipcRemoveListener('performNERResult', this.onPerformNERResults)
-    fairCopy.ipcRemoveListener('performNERFailed', this.onNERFailed)
+    fairCopy.ipcRemoveListener('performAgentResult', this.onPerformAgentResults)
+    fairCopy.ipcRemoveListener('performAgentFailed', this.onAgentFailed)
   }
 
   refreshWindow() {
@@ -724,7 +724,7 @@ export default class MainWindow extends Component {
     }
   }
 
-  onPerformNERResults = (e, obj) => {
+  onPerformAgentResults = (e, obj) => {
     const { xml, docID } = obj
     const { openResources } = this.state
 
@@ -739,7 +739,7 @@ export default class MainWindow extends Component {
     this.setState({ ...this.state, runningAgent: false })
   }
 
-  onNERFailed = (e, obj) => {
+  onAgentFailed = (e, obj) => {
     const { error } = obj
     this.onAlertMessage(`Named Entity Recognition failed! error: ${error}`)
     this.setState({ ...this.state, runningAgent: false })

--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -388,8 +388,8 @@ export default class MainWindow extends Component {
     )
     fairCopy.ipcRegisterCallback('checkInStarted', this.onCheckInStarted)
     fairCopy.ipcRegisterCallback('checkInResults', this.onCheckInResults)
-    fairCopy.ipcRegisterCallback('performAgentResult', this.onPerformAgentResults)
-    fairCopy.ipcRegisterCallback('performAgentFailed', this.onAgentFailed)
+    fairCopy.ipcRegisterCallback('runAgentResult', this.onRunAgentResults)
+    fairCopy.ipcRegisterCallback('runAgentFailed', this.onAgentFailed)
   }
 
   componentWillUnmount() {
@@ -423,8 +423,8 @@ export default class MainWindow extends Component {
     )
     fairCopy.ipcRemoveListener('checkInStarted', this.onCheckInStarted)
     fairCopy.ipcRemoveListener('checkInResults', this.onCheckInResults)
-    fairCopy.ipcRemoveListener('performAgentResult', this.onPerformAgentResults)
-    fairCopy.ipcRemoveListener('performAgentFailed', this.onAgentFailed)
+    fairCopy.ipcRemoveListener('runAgentResult', this.onRunAgentResults)
+    fairCopy.ipcRemoveListener('runAgentFailed', this.onAgentFailed)
   }
 
   refreshWindow() {
@@ -724,7 +724,7 @@ export default class MainWindow extends Component {
     }
   }
 
-  onPerformAgentResults = (e, obj) => {
+  onRunAgentResults = (e, obj) => {
     const { xml, docID } = obj
     const { openResources } = this.state
 

--- a/src/render/components/main-window/tei-editor/EditorToolbar.jsx
+++ b/src/render/components/main-window/tei-editor/EditorToolbar.jsx
@@ -87,7 +87,7 @@ export default class EditorToolbar extends Component {
     onAgent = () => {
         const { teiDocument } = this.props
         this.props.onRunAgent()
-        teiDocument.performAgent()
+        teiDocument.runAgent()
     }
 
     onFind = () => {

--- a/src/render/components/main-window/tei-editor/EditorToolbar.jsx
+++ b/src/render/components/main-window/tei-editor/EditorToolbar.jsx
@@ -84,10 +84,10 @@ export default class EditorToolbar extends Component {
         teiDocument.previewDocument()
     }
 
-    onNER = () => {
+    onAgent = () => {
         const { teiDocument } = this.props
         this.props.onRunAgent()
-        teiDocument.performNER()
+        teiDocument.performAgent()
     }
 
     onFind = () => {
@@ -140,7 +140,7 @@ export default class EditorToolbar extends Component {
         const { menus } = fairCopyProject.fairCopyConfig
         const { elements } = fairCopyProject.teiSchema
         const canPreview = !fairCopyProject.remote || (fairCopyProject.remote && fairCopyProject.isLoggedIn())
-        const canNER = ['text', 'sourceDoc'].includes(teiDocument.resourceType) && !changedSinceLastSave && 
+        const canAgent = ['text', 'sourceDoc'].includes(teiDocument.resourceType) && !changedSinceLastSave && 
             (!fairCopyProject.remote || (fairCopyProject.remote && fairCopyProject.isLoggedIn()))
         const onAction = (member) => {
             const selection = (editorView) ? editorView.state.selection : null 
@@ -170,7 +170,7 @@ export default class EditorToolbar extends Component {
                 <div className="rightgroup">
                     { this.renderButton("Edit Properties", "fas fa-edit", onEditResource ) }
                     { this.renderButton("Save", "fas fa-save", onSave, changedSinceLastSave ) }
-                    { this.renderButton("Perform NER on Document", "fas fa-people-group", this.onNER, canNER ) }
+                    { this.renderButton("Perform Agent on Document", "fas fa-people-group", this.onAgent, canAgent ) }
                 </div>
                 { elementMenuOptions && <ElementMenu
                         menus={menus}

--- a/src/render/model/TEIDocument.js
+++ b/src/render/model/TEIDocument.js
@@ -390,12 +390,12 @@ export default class TEIDocument {
     this.changedSinceLastSave = false
   }
 
-  performNER() {
+  performAgent() {
     const editorState = this.editorView.state
     const teiSchema = this.getTEISchema()
 
     const fileContents = serializeText(editorState.doc, this, teiSchema)
 
-    fairCopy.ipcSend('performNER', fileContents, this.resourceEntry.id)
+    fairCopy.ipcSend('performAgent', fileContents, this.resourceEntry.id)
   }
 }

--- a/src/render/model/TEIDocument.js
+++ b/src/render/model/TEIDocument.js
@@ -390,12 +390,12 @@ export default class TEIDocument {
     this.changedSinceLastSave = false
   }
 
-  performAgent() {
+  runAgent() {
     const editorState = this.editorView.state
     const teiSchema = this.getTEISchema()
 
     const fileContents = serializeText(editorState.doc, this, teiSchema)
 
-    fairCopy.ipcSend('performAgent', fileContents, this.resourceEntry.id)
+    fairCopy.ipcSend('runAgent', fileContents, this.resourceEntry.id)
   }
 }

--- a/src/render/model/cloud-api/projects.js
+++ b/src/render/model/cloud-api/projects.js
@@ -82,11 +82,11 @@ export function publishCss(userID, projectID, serverURL, authToken, onSuccess, o
     )
 }
 
-export async function performAgent(userID, serverURL, projectID, authToken, fileContents, onSuccess, onFail) {
-    const performAgentURL = `${serverURL}/api/agents/run`
+export async function runAgent(userID, serverURL, projectID, authToken, fileContents, onSuccess, onFail) {
+    const runAgentURL = `${serverURL}/api/agents/run`
 
     try {
-        const performResp = await axios.post(performAgentURL, { tei: fileContents, projectID, serverURL, authToken }, authConfig(authToken))
+        const performResp = await axios.post(runAgentURL, { tei: fileContents, projectID, serverURL, authToken }, authConfig(authToken))
         const { run_id } = performResp.data
         const statusURL = `${serverURL}/api/agents/status/${run_id}`
         let attempts = 0

--- a/src/render/model/cloud-api/projects.js
+++ b/src/render/model/cloud-api/projects.js
@@ -4,8 +4,8 @@ import { authConfig } from './auth'
 import { standardErrorHandler } from './error-handler'
 import { getUserOrganizations } from './auth'
 
-const MAX_NER_POLLS = 1000        // Maximum number of status requests for a single NER request
-const NER_POLL_INTERVAL = 5000    // How often to poll NER status endpoint in ms
+const MAX_AGENT_POLLS = 1000        // Maximum number of status requests for a single AGENT request
+const AGENT_POLL_INTERVAL = 5000    // How often to poll AGENT status endpoint in ms
 
 export function getProjects(userID, serverURL, authToken, onSuccess, onFail) {
     const getProjectsURL = `${serverURL}/api/projects?per_page=1000`
@@ -82,18 +82,18 @@ export function publishCss(userID, projectID, serverURL, authToken, onSuccess, o
     )
 }
 
-export async function performNER(userID, serverURL, authToken, fileContents, onSuccess, onFail) {
-    const performNERURL = `${serverURL}/api/agents/ner`
+export async function performAgent(userID, serverURL, projectID, authToken, fileContents, onSuccess, onFail) {
+    const performAgentURL = `${serverURL}/api/agents/run`
 
     try {
-        const performResp = await axios.post(performNERURL, { tei: fileContents }, authConfig(authToken))
+        const performResp = await axios.post(performAgentURL, { tei: fileContents, projectID, serverURL, authToken }, authConfig(authToken))
         const { run_id } = performResp.data
-        const statusURL = `${serverURL}/api/agents/ner/status/${run_id}`
+        const statusURL = `${serverURL}/api/agents/status/${run_id}`
         let attempts = 0
 
         // We will poll until completed or failed
         const goodStatus = ['RUNNING', 'COMPLETED']
-        while (attempts < MAX_NER_POLLS) {
+        while (attempts < MAX_AGENT_POLLS) {
             try {
                 const statusResp = await axios.get(statusURL, authConfig(authToken))
 
@@ -104,7 +104,7 @@ export async function performNER(userID, serverURL, authToken, fileContents, onS
                 }
 
                 if (status === 'COMPLETED') {
-                    const retrieveURL = `${serverURL}/api/agents/ner/retrieve/${run_id}`
+                    const retrieveURL = `${serverURL}/api/agents/retrieve/${run_id}`
 
                     try {
                         const retrieveResp = await axios.get(retrieveURL, authConfig(authToken))
@@ -120,8 +120,8 @@ export async function performNER(userID, serverURL, authToken, fileContents, onS
                 }
 
                 attempts++
-                if (attempts < MAX_NER_POLLS) {
-                    await new Promise(resolve => setTimeout(resolve, NER_POLL_INTERVAL)) // Wait before next attempt
+                if (attempts < MAX_AGENT_POLLS) {
+                    await new Promise(resolve => setTimeout(resolve, AGENT_POLL_INTERVAL)) // Wait before next attempt
                 }
             } catch (error) {
                 onFail(error)

--- a/src/render/workers/remote-project-worker.js
+++ b/src/render/workers/remote-project-worker.js
@@ -1,5 +1,5 @@
 import { getResource, getResources } from "../model/cloud-api/resources"
-import { getProject, performAgent, publishCss } from "../model/cloud-api/projects"
+import { getProject, runAgent, publishCss } from "../model/cloud-api/projects"
 import { getAuthToken } from '../model/cloud-api/auth'
 import { getIDMap } from "../model/cloud-api/id-map"
 import { connectCable } from "../model/cloud-api/activity-cable"
@@ -78,8 +78,8 @@ function onPublishCss(userID, serverURL, projectID, authToken, postMessage) {
         })
 }
 
-function onPerformAgent(userID, serverURL, projectID, authToken, fileContents, docID, postMessage) {
-    performAgent(userID, serverURL, projectID, authToken, fileContents, (data) => {
+function onRunAgent(userID, serverURL, projectID, authToken, fileContents, docID, postMessage) {
+    runAgent(userID, serverURL, projectID, authToken, fileContents, (data) => {
         postMessage({ messageType: 'agent-updated', xml: data, docID })
     },
         (error) => {
@@ -245,7 +245,7 @@ export function remoteProject(msg, workerMethods, workerData) {
             break
         case 'perform-ner':
             const { fileContents, docID } = msg
-            onPerformAgent(userID, serverURL, projectID, authToken, fileContents, docID, postMessage)
+            onRunAgent(userID, serverURL, projectID, authToken, fileContents, docID, postMessage)
             break
         case 'refresh-project-info':
             updateProjectInfo(userID, serverURL, authToken, projectID, postMessage)

--- a/src/render/workers/remote-project-worker.js
+++ b/src/render/workers/remote-project-worker.js
@@ -1,5 +1,5 @@
 import { getResource, getResources } from "../model/cloud-api/resources"
-import { getProject, performNER, publishCss } from "../model/cloud-api/projects"
+import { getProject, performAgent, publishCss } from "../model/cloud-api/projects"
 import { getAuthToken } from '../model/cloud-api/auth'
 import { getIDMap } from "../model/cloud-api/id-map"
 import { connectCable } from "../model/cloud-api/activity-cable"
@@ -78,12 +78,12 @@ function onPublishCss(userID, serverURL, projectID, authToken, postMessage) {
         })
 }
 
-function onPerformNER(userID, serverURL, authToken, fileContents, docID, postMessage) {
-    performNER(userID, serverURL, authToken, fileContents, (data) => {
-        postMessage({ messageType: 'ner-updated', xml: data, docID })
+function onPerformAgent(userID, serverURL, projectID, authToken, fileContents, docID, postMessage) {
+    performAgent(userID, serverURL, projectID, authToken, fileContents, (data) => {
+        postMessage({ messageType: 'agent-updated', xml: data, docID })
     },
         (error) => {
-            postMessage({ messageType: 'ner-failed', error })
+            postMessage({ messageType: 'agent-failed', error })
         })
 }
 
@@ -245,7 +245,7 @@ export function remoteProject(msg, workerMethods, workerData) {
             break
         case 'perform-ner':
             const { fileContents, docID } = msg
-            onPerformNER(userID, serverURL, authToken, fileContents, docID, postMessage)
+            onPerformAgent(userID, serverURL, projectID, authToken, fileContents, docID, postMessage)
             break
         case 'refresh-project-info':
             updateProjectInfo(userID, serverURL, authToken, projectID, postMessage)


### PR DESCRIPTION
### In this PR
- Adds the `projectID` value to the inputs for the function called when the run agent button is pressed, so that the Trigger task can pull in the project config to determine which agent to run based on the configured parser;
- Renames a bunch of stuff to be less confusing given that NER is now just one possible option. (I wasn't sure what would be good to rename to so I just went for something super generic, but open to other ideas...)