### PR TITLE
Reconciliation API implementation (#665)

### DIFF
--- a/src/main-process/FairCopyApplication.js
+++ b/src/main-process/FairCopyApplication.js
@@ -178,6 +178,14 @@ class FairCopyApplication {
       this.fairCopySession.runAgent(fileContents, docID)
     })
 
+    ipcMain.on('requestReconciliationManifest', (event, manifestData) => {
+      this.fairCopySession.requestReconciliationManifest(manifestData)
+    })
+
+    ipcMain.on('requestReconciliationQuery', (event, queryData) => {
+      this.fairCopySession.requestReconciliationQuery(queryData)
+    })
+
     ipcMain.on('requestSaveConfig', (event, fairCopyConfig, lastAction) => { this.fairCopySession.saveFairCopyConfig(fairCopyConfig, lastAction) })
     ipcMain.on('checkInConfig', (event, fairCopyConfig, firstAction) => { this.fairCopySession.checkInConfig(fairCopyConfig, firstAction) })
     ipcMain.on('checkOutConfig', (event) => { this.fairCopySession.checkOutConfig() })

--- a/src/main-process/FairCopySession.js
+++ b/src/main-process/FairCopySession.js
@@ -548,6 +548,18 @@ class FairCopySession {
         this.remoteProject.runAgent(fileContents, docID)
     }
 
+    requestReconciliationManifest(manifestData) {
+        const { endpoint, requestID } = manifestData
+        if (this.remoteProject) {
+            this.remoteProject.getReconciliationManifest(endpoint, requestID)
+        }
+    }
+
+    requestReconciliationQuery(reonciliationData) {
+        const { endpoint, query, dataType, requestID } = reonciliationData
+        this.remoteProject.queryReconciliation(endpoint, query, dataType, requestID)
+    }
+
     saveFairCopyConfig(fairCopyConfig, lastAction) {
         this.projectStore.saveFairCopyConfig(fairCopyConfig, lastAction)
     }

--- a/src/main-process/RemoteProject.js
+++ b/src/main-process/RemoteProject.js
@@ -123,6 +123,34 @@ class RemoteProject {
                         fairCopyApplication.sendToMainWindow('runAgentFailed', { error })
                     }
                     break
+                case 'reconciliation-manifest-result':
+                    {
+                        const { data, requestID } = msg
+                        const { fairCopyApplication } = this.fairCopySession
+                        fairCopyApplication.sendToMainWindow('reconciliationManifestResult', { data, requestID })
+                    }
+                    break
+                case 'reconciliation-manifest-failed':
+                    {
+                        const { error, requestID } = msg
+                        const { fairCopyApplication } = this.fairCopySession
+                        fairCopyApplication.sendToMainWindow('reconciliationManifestFailed', { error, requestID })
+                    }
+                    break
+                case 'reconciliation-result':
+                    {
+                        const { results, requestID } = msg
+                        const { fairCopyApplication } = this.fairCopySession
+                        fairCopyApplication.sendToMainWindow('reconciliationResult', { results, requestID })
+                    }
+                    break
+                case 'reconciliation-failed':
+                    {
+                        const { error, requestID } = msg
+                        const { fairCopyApplication } = this.fairCopySession
+                        fairCopyApplication.sendToMainWindow('reconciliationFailed', { error, requestID })
+                    }
+                    break
                 default:
                     throw new Error(`Unrecognized message type ${messageType} received from remote project: ${JSON.stringify(msg)}`)
             }
@@ -177,6 +205,14 @@ class RemoteProject {
 
     runAgent(fileContents, docID) {
         this.remoteProjectWorker.postMessage({ messageType: 'perform-ner', fileContents, docID })
+    }
+
+    getReconciliationManifest(endpoint, requestID) {
+        this.remoteProjectWorker.postMessage({ messageType: 'get-reconciliation-manifest', endpoint, requestID })
+    }
+
+    queryReconciliation(endpoint, query, dataType, requestID) {
+        this.remoteProjectWorker.postMessage({ messageType: 'query-reconciliation', endpoint, query, dataType, requestID })
     }
 }
 

--- a/src/render/components/main-window/dialogs/AttributeDialog.jsx
+++ b/src/render/components/main-window/dialogs/AttributeDialog.jsx
@@ -1,9 +1,173 @@
 import React, { Component } from 'react';
-import { Table, TableHead, TableBody, TableRow, TableCell, Typography } from '@material-ui/core'
-import { Dialog, DialogContent, DialogTitle, DialogActions } from '@material-ui/core'
-import { Button, Checkbox } from '@material-ui/core'
+import {
+    Button,
+    Checkbox,
+    CircularProgress,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    FormControlLabel,
+    Switch,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+    TextField,
+    Typography,
+} from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
+import { v4 as uuidv4 } from 'uuid';
+
+const fairCopy = window.fairCopy;
+
+class ReconciliationConfigDialog extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            config: props.config || { active: false, endpoint: '', dataType: '' },
+            manifestTypes: [],
+            loading: false
+        };
+        this.requestID = uuidv4();
+        this.fetchTimeout = null;
+    }
+
+    componentDidMount() {
+        if (fairCopy?.ipcRegisterCallback) {
+            fairCopy.ipcRegisterCallback('reconciliationManifestResult', this.handleManifestResult);
+            fairCopy.ipcRegisterCallback('reconciliationManifestFailed', this.handleManifestFailed);
+        }
+
+        if (this.state.config.endpoint) {
+            this.fetchManifest(this.state.config.endpoint);
+        }
+    }
+
+    componentWillUnmount() {
+        if (fairCopy?.ipcRemoveListener) {
+            fairCopy.ipcRemoveListener('reconciliationManifestResult', this.handleManifestResult);
+            fairCopy.ipcRemoveListener('reconciliationManifestFailed', this.handleManifestFailed);
+        }
+    }
+
+    handleManifestResult = (event, payload) => {
+        if (payload.requestID === this.requestID) {
+            const data = payload.data;
+            if (data.defaultTypes) {
+                const typeIds = data.defaultTypes.map(t => t.id);
+                const viewUrl = data.view?.url || '';
+                this.updateConfig({ viewUrl });
+                this.setState({ manifestTypes: typeIds, loading: false });
+            } else {
+                this.setState({ manifestTypes: [], loading: false });
+            }
+        }
+    }
+
+    handleManifestFailed = (event, payload) => {
+        if (payload.requestID === this.requestID) {
+            console.error("Failed to fetch reconciliation manifest:", payload.error);
+            this.setState({ manifestTypes: [], loading: false });
+        }
+    }
+
+    fetchManifest = (url) => {
+        if (!url) return;
+        this.setState({ loading: true });
+        fairCopy.ipcSend('requestReconciliationManifest', {
+            endpoint: url,
+            requestID: this.requestID
+        });
+    }
+
+    updateConfig = (updates) => {
+        const nextConfig = { ...this.state.config, ...updates };
+        this.setState({ config: nextConfig });
+
+        if (updates.endpoint !== undefined) {
+            if (this.fetchTimeout) clearTimeout(this.fetchTimeout);
+            this.fetchTimeout = setTimeout(() => {
+                this.fetchManifest(nextConfig.endpoint);
+            }, 500);
+        }
+    }
+
+    render() {
+        const { currentAttribute, onClose, onSave } = this.props;
+        const { config, manifestTypes, loading } = this.state;
+
+        return (
+            <Dialog open={true} onClose={onClose} aria-labelledby="reconciliation-config-dialog">
+                <DialogTitle id="reconciliation-config-dialog">Autocomplete: {currentAttribute}</DialogTitle>
+                <DialogContent style={{ display: 'flex', flexDirection: 'column', gap: '16px', minWidth: '400px', paddingTop: '8px' }}>
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={config.active}
+                                onChange={(e) => this.updateConfig({ active: e.target.checked })}
+                                color="primary"
+                            />
+                        }
+                        label="Enable Remote Data Source"
+                    />
+                    <TextField
+                        label="Reconciliation Manifest URL"
+                        variant="outlined"
+                        fullWidth
+                        disabled={!config.active}
+                        value={config.endpoint || ''}
+                        onChange={(e) => this.updateConfig({ endpoint: e.target.value })}
+                    />
+                    <Autocomplete
+                        freeSolo
+                        disabled={!config.active}
+                        options={manifestTypes}
+                        value={config.dataType || ''}
+                        onChange={(event, newValue) => {
+                            this.updateConfig({ dataType: newValue || '' });
+                        }}
+                        onInputChange={(event, newInputValue) => {
+                            this.updateConfig({ dataType: newInputValue });
+                        }}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="Data Type (Optional)"
+                                variant="outlined"
+                                helperText={loading ? "Fetching types from API..." : "Type filter for reconciliation queries"}
+                                InputProps={{
+                                    ...params.InputProps,
+                                    endAdornment: (
+                                        <React.Fragment>
+                                            {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                                            {params.InputProps.endAdornment}
+                                        </React.Fragment>
+                                    ),
+                                }}
+                            />
+                        )}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => onSave(config)} color="primary">
+                        Done
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        );
+    }
+}
 
 export default class AttributeDialog extends Component {
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            currentAttribute: null
+        };
+    }
 
     renderTable() {
         const {elementName, teiSchema, fairCopyConfig, onUpdateConfig} = this.props
@@ -13,18 +177,20 @@ export default class AttributeDialog extends Component {
         const tableRows = []
         for( const attrName of Object.keys(attrState) ) {
             const attr = teiSchema.getAttrSpec( attrName, elementName )
-    
+
             if( !attr.hidden ) {
                 const onChange = () => {
                     const active = !attrState[attrName].active
                     fairCopyConfig.elements[elementName].attrState[attrName] = { ...attrState[attrName], active }
                     onUpdateConfig(fairCopyConfig)
                 }
-            
+
+                const isPointer = attr.dataType === "teidata.pointer";
+
                 tableRows.push(
                     <TableRow key={`attr-row-${attrName}`} >
                         <TableCell>
-                          <Checkbox
+                            <Checkbox
                                 color="primary"
                                 checked={attrState[attrName].active}
                                 onChange={onChange}
@@ -32,11 +198,22 @@ export default class AttributeDialog extends Component {
                         </TableCell>
                         <TableCell>{attrName}</TableCell>
                         <TableCell>{attr.description}</TableCell>
-                    </TableRow>    
-                )    
+                        <TableCell>
+                            {isPointer && (
+                                <Button
+                                    size="small"
+                                    variant="outlined"
+                                    onClick={() => this.setState({ currentAttribute: attrName })}
+                                >
+                                    Configure
+                                </Button>
+                            )}
+                        </TableCell>
+                    </TableRow>
+                )
             }
         }
-        
+
         return (
             <Table>
                 <TableHead>
@@ -45,6 +222,7 @@ export default class AttributeDialog extends Component {
                         </TableCell>
                         <TableCell>Name</TableCell>
                         <TableCell>Description</TableCell>
+                        <TableCell>Autocomplete</TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>
@@ -55,6 +233,31 @@ export default class AttributeDialog extends Component {
     }
 
 
+    renderReconciliationConfig() {
+        const { currentAttribute } = this.state;
+        const { elementName, fairCopyConfig, onUpdateConfig } = this.props;
+
+        if (!currentAttribute) return null;
+
+        const attrStateNode = fairCopyConfig.elements[elementName].attrState[currentAttribute];
+        const config = attrStateNode?.reconciliation || { active: false, endpoint: '', dataType: '' };
+
+        const handleSave = (newConfig) => {
+            attrStateNode.reconciliation = newConfig;
+            onUpdateConfig(fairCopyConfig);
+            this.setState({ currentAttribute: null });
+        };
+
+        return (
+            <ReconciliationConfigDialog
+                currentAttribute={currentAttribute}
+                config={config}
+                onClose={() => this.setState({ currentAttribute: null })}
+                onSave={handleSave}
+            />
+        );
+    }
+
     render() {
         const { open, onClose, elementName } = this.props
 
@@ -62,18 +265,21 @@ export default class AttributeDialog extends Component {
         const displayName = elementName.startsWith('mark') ? elementName.slice('mark'.length) : elementName
 
         return (
-            <Dialog open={open} onClose={onClose} aria-labelledby="attribute-dialog">
-                <DialogTitle id="attribute-dialog">Available Attributes for {displayName}</DialogTitle>
-                <DialogContent>
-                    <Typography>Select attributes to describe this element. These attributes will appear for every instance of {displayName}.</Typography>
-                    { this.renderTable() }                    
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={onClose} color="primary">
-                        Done
-                    </Button>
-                </DialogActions>
-            </Dialog>
+            <>
+                <Dialog open={open} onClose={onClose} aria-labelledby="attribute-dialog">
+                    <DialogTitle id="attribute-dialog">Available Attributes for {displayName}</DialogTitle>
+                    <DialogContent>
+                        <Typography>Select attributes to describe this element. These attributes will appear for every instance of {displayName}.</Typography>
+                        { this.renderTable() }
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={onClose} color="primary">
+                            Done
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+                {this.renderReconciliationConfig()}
+            </>
         )
     }
 

--- a/src/render/components/main-window/dialogs/AttributeDialog.jsx
+++ b/src/render/components/main-window/dialogs/AttributeDialog.jsx
@@ -56,10 +56,9 @@ class ReconciliationConfigDialog extends Component {
         if (payload.requestID === this.requestID) {
             const data = payload.data;
             if (data.defaultTypes) {
-                const typeIds = data.defaultTypes.map(t => t.id);
                 const viewUrl = data.view?.url || '';
                 this.updateConfig({ viewUrl });
-                this.setState({ manifestTypes: typeIds, loading: false });
+                this.setState({ manifestTypes: data.defaultTypes, loading: false });
             } else {
                 this.setState({ manifestTypes: [], loading: false });
             }
@@ -124,13 +123,48 @@ class ReconciliationConfigDialog extends Component {
                         freeSolo
                         disabled={!config.active}
                         options={manifestTypes}
-                        value={config.dataType || ''}
+                        value={
+                            manifestTypes.find(t => t.id === config.dataType) ||
+                            (
+                                config.dataType
+                                    ? {
+                                        id: config.dataType,
+                                        name: config.dataTypeName || config.dataType
+                                    }
+                                    : null
+                            )
+                        }
+                        getOptionLabel={(option) => {
+                            if (typeof option === 'string') {
+                                return option;
+                            }
+                            return option.name || option.id || '';
+                        }}
                         onChange={(event, newValue) => {
-                            this.updateConfig({ dataType: newValue || '' });
+                            if (!newValue) {
+                                // input cleared
+                                this.updateConfig({ dataType: '', dataTypeName: '' });
+                            } else if (typeof newValue === 'string') {
+                                // string not picked from defaultTypes
+                                this.updateConfig({ dataType: newValue, dataTypeName: newValue });
+                            } else {
+                                // object picked from defaultTypes
+                                this.updateConfig({ dataType: newValue.id, dataTypeName: newValue.name });
+                            }
                         }}
                         onInputChange={(event, newInputValue) => {
                             this.updateConfig({ dataType: newInputValue });
                         }}
+                        renderOption={(option) => (
+                            <div>
+                                <Typography variant="body1">
+                                    {option.name}
+                                </Typography>
+                                <Typography variant="caption" color="textSecondary" style={{ display: 'block' }}>
+                                    {option.id}
+                                </Typography>
+                            </div>
+                        )}
                         renderInput={(params) => (
                             <TextField
                                 {...params}

--- a/src/render/components/main-window/tei-editor/ParameterDrawer.jsx
+++ b/src/render/components/main-window/tei-editor/ParameterDrawer.jsx
@@ -28,7 +28,7 @@ import IDField from "./attribute-fields/IDField";
 import ReadOnlyField from "./attribute-fields/ReadOnlyField";
 
 import { changeAttributes } from "../../../model/commands";
-import { getHighlightColor } from "../../../model/highlighter";
+import { getHighlightColor, getHighlightRanges } from "../../../model/highlighter";
 import { checkID } from "../../../model/attribute-validators";
 import { saveConfig, addElementToSchema } from "../../../model/faircopy-config";
 import {
@@ -170,7 +170,7 @@ export default class ParameterDrawer extends Component {
     );
   }
 
-  renderAttributeField(elementName, attrName, value, attrSpec, onChange) {
+  renderAttributeField(element, elementName, attrName, value, attrSpec, onChange) {
     const { readOnly, canEditConfig } = this.props;
     const { dataType, minOccurs, maxOccurs, valListType } = attrSpec;
 
@@ -218,8 +218,33 @@ export default class ParameterDrawer extends Component {
     }
     if (dataType === "teidata.pointer") {
       const { teiDocument } = this.props;
+      const { fairCopyConfig } = teiDocument.fairCopyProject;
+      const attrStateNode = fairCopyConfig?.elements?.[elementName]?.attrState?.[attrName];
+      const reconciliationConfig = attrStateNode?.reconciliation;
+
+      // attempt to get element plaintext content to pre-fill autocomplete
+      let elementText = "";
+      if (element instanceof Node) {
+        elementText = element.textContent;
+      } else {
+        const { state } = teiDocument.getActiveView();
+        const { empty, $anchor, from, to } = state.selection;
+        if (!empty) {
+          // use selection state
+          elementText = state.doc.textBetween(from, to, " ");
+        } else {
+          // use active highlight range
+          const ranges = getHighlightRanges(state.doc, $anchor);
+          const activeRange = ranges.find(r => r.mark === element);
+          if (activeRange && activeRange.from !== undefined && activeRange.to !== undefined) {
+            elementText = state.doc.textBetween(activeRange.from, activeRange.to, " ");
+          }
+        }
+      }
+
       return (
         <TEIDataPointerField
+          elementText={elementText}
           elementName={elementName}
           attrName={attrName}
           minOccurs={minOccurs}
@@ -229,6 +254,7 @@ export default class ParameterDrawer extends Component {
           fairCopyProject={teiDocument.fairCopyProject}
           value={value}
           onChangeCallback={onChange}
+          reconciliationConfig={reconciliationConfig}
         ></TEIDataPointerField>
       );
     }
@@ -327,6 +353,7 @@ export default class ParameterDrawer extends Component {
         attrFields.push(
           <div className="attrField" key={fieldKey}>
             {this.renderAttributeField(
+              element,
               elementID,
               key,
               value,

--- a/src/render/components/main-window/tei-editor/attribute-fields/TEIDataPointerField.jsx
+++ b/src/render/components/main-window/tei-editor/attribute-fields/TEIDataPointerField.jsx
@@ -80,15 +80,12 @@ export default class TEIDataPointerField extends Component {
       return;
     }
 
-    // strip leading # for saved uuids
-    const cleanQuery = query && query.startsWith('#') ? query.slice(1) : query;
-
     this.setState({ loading: true });
 
     // make the request to the reconciliation API endpoint with the query and data type
     fairCopy.ipcSend('requestReconciliationQuery', {
       endpoint: reconciliationConfig.endpoint,
-      query: cleanQuery,
+      query,
       dataType: reconciliationConfig.dataType,
       requestID: this.requestID
     });
@@ -139,7 +136,7 @@ export default class TEIDataPointerField extends Component {
       if (value && reconciliationConfig?.viewUrl) {
           // strip underscore for NBU backwards compatibility
           let cleanId = value.startsWith('_') ? value.slice(1) : value;
-          // strip leading #
+          // strip leading # for NBU backwards compatibility
           cleanId = cleanId.startsWith('#') ? cleanId.slice(1) : cleanId;
           // replace {{id}} with the actual ID
           const targetUrl = reconciliationConfig.viewUrl.replace('{{id}}', cleanId);
@@ -190,10 +187,6 @@ export default class TEIDataPointerField extends Component {
 
     const onChange = (e, selectedValue) => {
       let value = selectedValue?.id ? selectedValue.id : (selectedValue || "");
-      if (isReconciliation && selectedValue?.id && !value.startsWith('#')) {
-        // add leading #
-        value = `#${value}`;
-      }
       if (value && value !== "") {
         const validResult = this.validateValues([value]);
         this.setState(validResult);
@@ -273,14 +266,7 @@ export default class TEIDataPointerField extends Component {
     }
 
     const onChange = (e, newOptions) => {
-      const newValues = newOptions.map(opt => {
-        let val = opt.value || opt.id || opt;
-        // add leading #
-        if (isReconciliation && (opt.value || opt.id) && !val.startsWith('#')) {
-           val = `#${val}`;
-        }
-        return val;
-      });
+      const newValues = newOptions.map(opt => opt.value || opt.id || opt );
       const validResult = this.validateValues(newValues);
       this.setState(validResult);
       const str = newValues.join(" ");

--- a/src/render/components/main-window/tei-editor/attribute-fields/TEIDataPointerField.jsx
+++ b/src/render/components/main-window/tei-editor/attribute-fields/TEIDataPointerField.jsx
@@ -1,24 +1,109 @@
 import React, { Component } from "react";
-import { TextField, Chip } from "@material-ui/core";
+import { v4 as uuidv4 } from 'uuid';
+import { Chip, CircularProgress, IconButton, TextField, Typography } from "@material-ui/core";
 import { Autocomplete } from "@material-ui/lab";
-
 import { uriValidator } from "../../../../model/attribute-validators";
+
+const fairCopy = window.fairCopy;
 
 export default class TEIDataPointerField extends Component {
   constructor(props) {
-    super();
-    const { value, maxOccurs } = props;
+    super(props);
+    const { elementText, maxOccurs, value } = props;
 
+    let initialValidState = { error: false, errorMessage: "", errorValues: [] };
     if (value && value !== "") {
-      if (maxOccurs) {
-        const values = value.split(" ");
-        this.state = this.validateValues(values);
-      } else {
-        this.state = this.validateValues([value]);
-      }
-    } else {
-      this.state = {};
+      const values = maxOccurs ? value.split(" ") : [value];
+      initialValidState = this.validateValues(values);
     }
+    this.state = {
+      ...initialValidState,
+      reconciliationOptions: [],
+      loading: false,
+      inputValue: value ? String(value) : (elementText || ""),
+    };
+
+    this.requestID = uuidv4();
+    this.fetchTimeout = null;
+  }
+
+  componentDidMount() {
+    const { elementText, reconciliationConfig } = this.props;
+    fairCopy.ipcRegisterCallback('reconciliationResult', this.handleReconciliationResult);
+    fairCopy.ipcRegisterCallback('reconciliationFailed', this.handleReconciliationFailed);
+    if (reconciliationConfig?.active) {
+      // fetch API query results on mount
+      this.fetchReconciliationData(elementText || "");
+    }
+  }
+
+  componentWillUnmount() {
+    fairCopy.ipcRemoveListener('reconciliationResult', this.handleReconciliationResult);
+    fairCopy.ipcRemoveListener('reconciliationFailed', this.handleReconciliationFailed);
+    if (this.fetchTimeout) {
+      clearTimeout(this.fetchTimeout);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { elementText, value, reconciliationConfig } = this.props;
+
+    // ensure re-render updates input value appropriately
+    if (prevProps.elementText !== elementText || prevProps.value !== value) {
+      const newInputValue = value ? String(value) : (elementText || "");
+      this.setState({ inputValue: newInputValue });
+      if (reconciliationConfig?.active && newInputValue) {
+        // re-run the API query automatically in case we clicked on a different element
+        this.fetchReconciliationData(newInputValue);
+      }
+    }
+  }
+
+  handleReconciliationResult = (event, data) => {
+    if (data.requestID === this.requestID) {
+      this.setState({ reconciliationOptions: data.results, loading: false });
+    }
+  }
+
+  handleReconciliationFailed = (event, data) => {
+    if (data.requestID === this.requestID) {
+      console.error("Reconciliation API Error:", data.error);
+      this.setState({ reconciliationOptions: [], loading: false });
+    }
+  }
+
+  fetchReconciliationData = (query) => {
+    const { reconciliationConfig } = this.props;
+    if (!reconciliationConfig || !reconciliationConfig.active || !reconciliationConfig.endpoint || !query) {
+      // bail out if not configured
+      this.setState({ reconciliationOptions: [], loading: false });
+      return;
+    }
+
+    // strip leading # for saved uuids
+    const cleanQuery = query && query.startsWith('#') ? query.slice(1) : query;
+
+    this.setState({ loading: true });
+
+    // make the request to the reconciliation API endpoint with the query and data type
+    fairCopy.ipcSend('requestReconciliationQuery', {
+      endpoint: reconciliationConfig.endpoint,
+      query: cleanQuery,
+      dataType: reconciliationConfig.dataType,
+      requestID: this.requestID
+    });
+  }
+
+  onInputChange = (event, newInputValue, reason) => {
+    if (reason === 'reset' || reason === 'blur') {
+      return;
+    }
+    // set input value on state and query reconciliation API, debounced 300ms
+    this.setState({ inputValue: newInputValue });
+    if (this.fetchTimeout) clearTimeout(this.fetchTimeout);
+    this.fetchTimeout = setTimeout(() => {
+      this.fetchReconciliationData(newInputValue);
+    }, 300);
   }
 
   validateValues(values) {
@@ -41,11 +126,26 @@ export default class TEIDataPointerField extends Component {
   }
 
   renderInput = (params) => {
-    const { error, errorMessage } = this.state;
-    const { attrName, maxOccurs } = this.props;
+    const { error, errorMessage, loading } = this.state;
+    const { attrName, maxOccurs, reconciliationConfig, value } = this.props;
     const helperText =
       errorMessage && errorMessage.length > 0 ? errorMessage : " ";
     const variant = maxOccurs ? "outlined" : "standard";
+    const isReconciliation = reconciliationConfig?.active;
+
+    const onViewClick = (e) => {
+      e.stopPropagation();
+      // handle clicking the view link from the reconciliation API, if available
+      if (value && reconciliationConfig?.viewUrl) {
+          // strip underscore for NBU backwards compatibility
+          let cleanId = value.startsWith('_') ? value.slice(1) : value;
+          // strip leading #
+          cleanId = cleanId.startsWith('#') ? cleanId.slice(1) : cleanId;
+          // replace {{id}} with the actual ID
+          const targetUrl = reconciliationConfig.viewUrl.replace('{{id}}', cleanId);
+          fairCopy.ipcSend('openWebpage', targetUrl);
+      }
+    };
 
     return (
       <TextField
@@ -57,27 +157,49 @@ export default class TEIDataPointerField extends Component {
         fullWidth={true}
         error={error}
         helperText={helperText}
+        InputProps={{
+          ...params.InputProps,
+          endAdornment: (
+            <React.Fragment>
+              {loading && isReconciliation ? (
+                <CircularProgress color="inherit" size={20} />
+              ) : null}
+              {isReconciliation && reconciliationConfig?.viewUrl && value ? (
+                <IconButton size="small" onClick={onViewClick} title="View External Record">
+                  <i className="fas fa-external-link-alt" style={{ fontSize: '14px' }}></i>
+                </IconButton>
+              ) : null}
+              {params.InputProps.endAdornment}
+            </React.Fragment>
+          ),
+        }}
       />
     );
   };
 
   renderSingleTermField() {
-    const { fairCopyProject, resourceEntry, parentEntry, value } = this.props;
+    const { fairCopyProject, onChangeCallback, resourceEntry, parentEntry, value, reconciliationConfig } = this.props;
+    const isReconciliation = reconciliationConfig?.active;
     const { idMap } = fairCopyProject;
-    const IDs = idMap.getRelativeURIList(
-      resourceEntry.localID,
-      parentEntry?.localID
-    );
-    const key = `singleterm-${Date.now()}`;
+    let options = [];
+    if (isReconciliation) {
+      options = this.state.reconciliationOptions;
+    } else if (idMap) {
+      options = idMap.getRelativeURIList(resourceEntry?.localID, parentEntry?.localID);
+    }
 
-    const onChange = (e, value) => {
-      const { onChangeCallback } = this.props;
+    const onChange = (e, selectedValue) => {
+      let value = selectedValue?.id ? selectedValue.id : (selectedValue || "");
+      if (isReconciliation && selectedValue?.id && !value.startsWith('#')) {
+        // add leading #
+        value = `#${value}`;
+      }
       if (value && value !== "") {
         const validResult = this.validateValues([value]);
         this.setState(validResult);
         onChangeCallback(value, validResult.error);
       } else {
-        this.setState({});
+        this.setState({ error: false, errorMessage: "", errorValues: [] });
         onChangeCallback(value, false);
       }
     };
@@ -85,11 +207,32 @@ export default class TEIDataPointerField extends Component {
     return (
       <Autocomplete
         freeSolo
-        key={key}
-        value={value}
-        options={IDs}
+        value={value || ""}
+        options={options}
+        onInputChange={isReconciliation ? this.onInputChange : undefined}
+        inputValue={isReconciliation ? this.state.inputValue : undefined}
         onChange={onChange}
-        getOptionLabel={(option) => option}
+        getOptionLabel={(option) => option.name ? option.name : (option.id || option)}
+        renderOption={(option) => (
+          <div>
+            <Typography variant="body1">{option.name || option}</Typography>
+            {option.id && (
+              <Typography variant="caption" color="textSecondary" style={{ display: 'block' }}>
+                {option.id}
+              </Typography>
+            )}
+            {option.description && (
+              <Typography variant="caption" color="textSecondary" style={{ display: 'block' }}>
+                {option.description}
+              </Typography>
+            )}
+          </div>
+        )}
+        noOptionsText={
+          isReconciliation
+            ? "No matching records found on remote service."
+            : "No matching local XML:IDs found."
+        }
         renderInput={this.renderInput}
       />
     );
@@ -109,48 +252,87 @@ export default class TEIDataPointerField extends Component {
   }
 
   renderMultiTermField() {
-    const onChange = (e, selectedOptions) => {
-      const { onChangeCallback } = this.props;
-      const values = this.optionsToValues(selectedOptions);
-      const validResult = this.validateValues(values);
+    const { fairCopyProject, resourceEntry, parentEntry, value, reconciliationConfig, onChangeCallback } = this.props;
+    const { idMap } = fairCopyProject;
+
+    const isReconciliation = reconciliationConfig?.active;
+    const values = value && value.length > 0 ? value.split(" ") : [];
+    const selectedOptions = this.valuesToOptions(values);
+    let options = [];
+    if (isReconciliation) {
+      options = this.state.reconciliationOptions.map(opt => ({
+        value: opt.id,
+        label: opt.name,
+        description: opt.description,
+        error: false
+      }));
+    } else if (idMap) {
+      options = this.valuesToOptions(
+        idMap.getRelativeURIList(resourceEntry?.localID, parentEntry?.localID)
+      );
+    }
+
+    const onChange = (e, newOptions) => {
+      const newValues = newOptions.map(opt => {
+        let val = opt.value || opt.id || opt;
+        // add leading #
+        if (isReconciliation && (opt.value || opt.id) && !val.startsWith('#')) {
+           val = `#${val}`;
+        }
+        return val;
+      });
+      const validResult = this.validateValues(newValues);
       this.setState(validResult);
-      const str = values.join(" ");
+      const str = newValues.join(" ");
       onChangeCallback(str, validResult.error);
     };
 
-    const renderTags = (values, getTagProps) => {
-      return values.map((option, index) => {
+    const renderTags = (tagValues, getTagProps) => {
+      return tagValues.map((option, index) => {
         const color = option.error ? "red" : "black";
         return (
           <Chip
             variant="outlined"
             style={{ color, maxWidth: 200 }}
-            label={option.value}
+            label={option.label || option.value || option}
             {...getTagProps({ index })}
           />
         );
       });
     };
 
-    const { fairCopyProject, resourceEntry, parentEntry, value } = this.props;
-    const { idMap } = fairCopyProject;
-    const options = this.valuesToOptions(
-      idMap.getRelativeURIList(resourceEntry.localID, parentEntry?.localID)
-    );
-    const values = value && value.length > 0 ? value.split(" ") : [];
-    const selectedOptions = this.valuesToOptions(values);
-    const key = `multiterm-${Date.now()}`;
-
     return (
       <Autocomplete
         freeSolo
         multiple
         disableClearable
-        key={key}
         value={selectedOptions}
         options={options}
+        onInputChange={isReconciliation ? this.onInputChange : undefined}
+        inputValue={isReconciliation ? this.state.inputValue : undefined}
         onChange={onChange}
-        getOptionLabel={(option) => option.value}
+        getOptionLabel={(option) => option.label || option.value || option}
+        filterSelectedOptions
+        renderOption={(option) => (
+          <div>
+            <Typography variant="body1">{option.label || option.value || option}</Typography>
+            {option.id && (
+              <Typography variant="caption" color="textSecondary" style={{ display: 'block' }}>
+                {option.id}
+              </Typography>
+            )}
+            {option.description && (
+              <Typography variant="caption" color="textSecondary" style={{ display: 'block' }}>
+                {option.description}
+              </Typography>
+            )}
+          </div>
+        )}
+        noOptionsText={
+          isReconciliation
+            ? "No matching records found on remote service."
+            : "No matching local XML:IDs found."
+        }
         renderInput={this.renderInput}
         renderTags={renderTags}
       />
@@ -158,11 +340,12 @@ export default class TEIDataPointerField extends Component {
   }
 
   render() {
-    const { maxOccurs } = this.props;
+    const { maxOccurs, reconciliationConfig } = this.props;
+    const isReconciliation = reconciliationConfig?.active;
 
     return (
       <div style={{ display: "flex" }} className="data-pointer-wrapper">
-        {maxOccurs ? this.renderMultiTermField() : this.renderSingleTermField()}
+        {maxOccurs && !isReconciliation ? this.renderMultiTermField() : this.renderSingleTermField()}
       </div>
     );
   }

--- a/src/render/model/cloud-api/reconciliation.js
+++ b/src/render/model/cloud-api/reconciliation.js
@@ -1,0 +1,41 @@
+import axios from 'axios'
+
+export function getReconciliationManifest(endpoint, onSuccess, onFail) {
+    axios.get(endpoint, {
+        headers: {
+            'Accept': 'application/json'
+        }
+    }).then(
+        (response) => {
+            onSuccess(response.data)
+        },
+        (error) => {
+            onFail(error)
+        }
+    )
+}
+
+export function queryReconciliationAPI(endpoint, query, dataType, onSuccess, onFail) {
+    const payload = {
+        queries: {
+            q0: {
+                query: query,
+                type: dataType || undefined
+            }
+        }
+    }
+    axios.post(endpoint, payload, {
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+        }
+    }).then(
+        (response) => {
+            const results = response.data.q0?.result || []
+            onSuccess(results)
+        },
+        (error) => {
+            onFail(error)
+        }
+    )
+}

--- a/src/render/workers/remote-project-worker.js
+++ b/src/render/workers/remote-project-worker.js
@@ -6,6 +6,7 @@ import { connectCable } from "../model/cloud-api/activity-cable"
 import { getConfig, initConfig, checkInConfig, checkOutConfig } from "../model/cloud-api/config"
 import { getTeiDocument, publishTeiDocument } from "../model/cloud-api/tei-documents"
 import { abandonCheckout } from "../model/cloud-api/resource-management"
+import { getReconciliationManifest, queryReconciliationAPI } from "../model/cloud-api/reconciliation"
 
 function updateIDMap(userID, serverURL, authToken, projectID, postMessage) {
     getIDMap(userID, serverURL, authToken, projectID, (idMapData) => {
@@ -84,6 +85,22 @@ function onRunAgent(userID, serverURL, projectID, authToken, fileContents, docID
     },
         (error) => {
             postMessage({ messageType: 'agent-failed', error })
+        })
+}
+function onGetReconciliationManifest(endpoint, requestID, postMessage) {
+    getReconciliationManifest(endpoint, (data) => {
+        postMessage({ messageType: 'reconciliation-manifest-result', data, requestID })
+    }, (error) => {
+        postMessage({ messageType: 'reconciliation-manifest-failed', error, requestID })
+    })
+}
+
+function onQueryReconciliation(endpoint, query, dataType, requestID, postMessage) {
+    queryReconciliationAPI(endpoint, query, dataType, (results) => {
+        postMessage({ messageType: 'reconciliation-result', results, requestID })
+    },
+        (error) => {
+            postMessage({ messageType: 'reconciliation-failed', error, requestID })
         })
 }
 
@@ -246,6 +263,14 @@ export function remoteProject(msg, workerMethods, workerData) {
         case 'perform-ner':
             const { fileContents, docID } = msg
             onRunAgent(userID, serverURL, projectID, authToken, fileContents, docID, postMessage)
+            break
+        case 'query-reconciliation':
+            const { endpoint, query, dataType, requestID } = msg
+            onQueryReconciliation(endpoint, query, dataType, requestID, postMessage)
+            break
+        case 'get-reconciliation-manifest':
+            const { endpoint: manifestEndpoint, requestID: manifestReqID } = msg
+            onGetReconciliationManifest(manifestEndpoint, manifestReqID, postMessage)
             break
         case 'refresh-project-info':
             updateProjectInfo(userID, serverURL, authToken, projectID, postMessage)


### PR DESCRIPTION
## In this PR

Per #665:
- Add the option to configure a reconciliation API endpoint (and optional type filter) for `TEIDataPointer` attributes
   - Once the URL is entered, fetch the list of available types for the filter from the manifest's `defaultTypes`
- When configured, use the reconciliation API response instead of XML:IDs to populate attribute autocompletes
   - Pre-fill the autocomplete with the text content of the node or mark, and allow typing to change the query
   - Store selection's ID from the reconciliation API with a `#` prepended
   - Show an external link button with a computed view link, when available

## Questions

1. Do we want this to be available for _every_ `TEIDataPointer` attribute, or only `sameAs` or some other subset?
2. Is the whole format correct with the `#`? Going off Rebecca's comment in Slack + your note about only using `_` for NBU backwards compatibility.
3. Is it confusing to have the attribute appear to pre-populate with the element's text content, even when they haven't yet selected an authority record from the reconciliation API? Trying to figure out the most user-friendly way to do that.
   - I definitely see the utility in not requiring the user to type exactly what the text already says, but I wonder if it may appear as though reconciliation has already happened before they perform the query.

## Visual walkthrough

### Config flow

* Available Attributes now has a new column called "Autocomplete":
   <img width="1440" height="760" alt="Screenshot 2026-05-07 at 1 22 47 PM" src="https://github.com/user-attachments/assets/04b91f2d-daad-40cd-a4d0-2cfa4c94ce13" />

* Once the "enable remote data source" checkbox is toggled (i.e. choosing Reconciliation API instead of XML ID), the user can fill out the reconciliation API endpoint URL, and an optional type filter:
   <img width="1436" height="759" alt="Screenshot 2026-05-07 at 1 23 04 PM" src="https://github.com/user-attachments/assets/730dbd12-8d91-4f71-bd05-ad5c4e310649" />

* The type filter will fetch the `defaultTypes` from the reconciliation manifest to fill out the autocomplete:
   <img width="1439" height="763" alt="Screenshot 2026-05-07 at 1 23 15 PM" src="https://github.com/user-attachments/assets/268b9664-9c54-4ddf-94bb-a99306244018" />

### Editor flow

* Clicking a configured element or mark will auto-populate the attribute with its text content:
   <img width="1552" height="1111" alt="Screenshot 2026-05-07 at 4 22 54 PM" src="https://github.com/user-attachments/assets/c232eaec-6a36-4669-8e14-e89b260d6a60" />

* Clicking the autocomplete field will show you options from the reconciliation API:
   <img width="1552" height="1111" alt="Screenshot 2026-05-07 at 4 22 56 PM" src="https://github.com/user-attachments/assets/0fb085f4-37b8-4efe-ae89-994b2f04c7c2" />

* Typing will result in a query being sent to the reconciliation service (300ms debounced):
    <img width="1552" height="1111" alt="Screenshot 2026-05-07 at 4 23 18 PM" src="https://github.com/user-attachments/assets/c6bd3348-e601-4a40-ab32-855c386606e2" />

* On selection, the ID of the chosen authority record will populate the attribute, prefaced with `#`
* The "external link" button will take you to the view URL for that record, if one is configured in the manifest.
   <img width="1552" height="1111" alt="Screenshot 2026-05-07 at 4 22 59 PM" src="https://github.com/user-attachments/assets/4f74835c-bea2-4960-bd37-4f5984ada137" />

