### PR TITLE
Revert checkout feature

### DIFF
--- a/src/main-process/FairCopySession.js
+++ b/src/main-process/FairCopySession.js
@@ -585,6 +585,7 @@ class FairCopySession {
 
     abandonCheckout(resource) {
         this.remoteProject.abandonCheckout(resource)
+        this.projectStore.abandonResources([resource.id])
     }
 }
 

--- a/src/main-process/FairCopySession.js
+++ b/src/main-process/FairCopySession.js
@@ -585,7 +585,7 @@ class FairCopySession {
 
     abandonCheckout(resource) {
         this.remoteProject.abandonCheckout(resource)
-        this.projectStore.abandonResources([resource.id])
+        this.projectStore.abandonResource(resource.id)
     }
 }
 

--- a/src/main-process/ProjectStore.js
+++ b/src/main-process/ProjectStore.js
@@ -79,12 +79,6 @@ class ProjectStore {
                         }
                     }
                     break
-                case 'abandon-resources':
-                    {
-                        const { resourceIDs } = msg
-                        this.abandonResources(resourceIDs)
-                    }
-                    break
                 case 'cache-file-name':
                     {
                         const { cacheFile } = msg
@@ -424,13 +418,11 @@ class ProjectStore {
         this.projectArchiveWorker.postMessage({ messageType: 'read-resources', resourceIDs, abandoned })
     }
 
-    abandonResources(resourceIDs) {
+    abandonResource(resourceID) {
         const { userID } = this.manifestData
-        for( const resourceID of resourceIDs ) {
-            const resourceEntry = this.manifestData.resources[resourceID]
-            if( resourceEntry ) {
-                this.removeLocalResource(resourceID, userID, resourceEntry, 'abandon-check-out')
-            }
+        const resourceEntry = this.manifestData.resources[resourceID]
+        if( resourceEntry ) {
+            this.removeLocalResource(resourceID, userID, resourceEntry, 'abandon_check_out')
         }
     }
 

--- a/src/main-process/ProjectStore.js
+++ b/src/main-process/ProjectStore.js
@@ -78,7 +78,13 @@ class ProjectStore {
                             this.fairCopyApplication.createPreviewWindow(previewData).then(() => {})
                         }
                     }
-                    break  
+                    break
+                case 'abandon-resources':
+                    {
+                        const { resourceIDs } = msg
+                        this.abandonResources(resourceIDs)
+                    }
+                    break
                 case 'cache-file-name':
                     {
                         const { cacheFile } = msg
@@ -418,6 +424,16 @@ class ProjectStore {
         this.projectArchiveWorker.postMessage({ messageType: 'read-resources', resourceIDs, abandoned })
     }
 
+    abandonResources(resourceIDs) {
+        const { userID } = this.manifestData
+        for( const resourceID of resourceIDs ) {
+            const resourceEntry = this.manifestData.resources[resourceID]
+            if( resourceEntry ) {
+                this.removeLocalResource(resourceID, userID, resourceEntry, 'abandon-check-out')
+            }
+        }
+    }
+
     checkOutResults(resources,error) {        
         const checkOutStatus = []
         for( const resource of Object.values(resources) ) {
@@ -444,12 +460,7 @@ class ProjectStore {
         for( const resourceID of Object.keys(resourceStatus) ) {
             const resourceEntry = this.manifestData.resources[resourceID]
             if( !error ) {
-                // remove remote resources from project file and manifest, update all windows 
-                this.projectArchiveWorker.postMessage({ messageType: 'remove-file', fileID: resourceID })   
-                resourceEntry.local = false
-                resourceEntry.lastAction = { action_type: 'check_in', user: { id: userID } }
-                this.fairCopyApplication.sendToAllWindows('resourceEntryUpdated', resourceEntry )
-                delete this.manifestData.resources[resourceID]     
+                this.removeLocalResource(resourceID, userID, resourceEntry, 'check-in')
             }
             resourceEntries.push(resourceEntry)
         }
@@ -460,6 +471,15 @@ class ProjectStore {
             this.fairCopyApplication.fairCopySession.requestResourceView()
         }
         this.fairCopyApplication.sendToMainWindow('checkInResults', {resourceEntries, resourceStatus, error} ) 
+    }
+
+    // remove remote resources from project file and manifest, update all windows 
+    removeLocalResource(resourceID, userID, resourceEntry, lastActionType) {
+        this.projectArchiveWorker.postMessage({ messageType: 'remove-file', fileID: resourceID })
+        resourceEntry.local = false
+        resourceEntry.lastAction = { action_type: lastActionType, user: { id: userID } }
+        this.fairCopyApplication.sendToAllWindows('resourceEntryUpdated', resourceEntry )
+        delete this.manifestData.resources[resourceID]
     }
 
     // send a list of the local resources to main window

--- a/src/main-process/ProjectStore.js
+++ b/src/main-process/ProjectStore.js
@@ -422,7 +422,7 @@ class ProjectStore {
         const { userID } = this.manifestData
         const resourceEntry = this.manifestData.resources[resourceID]
         if( resourceEntry ) {
-            this.removeLocalResource(resourceID, userID, resourceEntry, 'abandon_check_out')
+            this.removeLocalResource(resourceID, userID, 'abandon_check_out')
         }
     }
 
@@ -452,7 +452,7 @@ class ProjectStore {
         for( const resourceID of Object.keys(resourceStatus) ) {
             const resourceEntry = this.manifestData.resources[resourceID]
             if( !error ) {
-                this.removeLocalResource(resourceID, userID, resourceEntry, 'check-in')
+                this.removeLocalResource(resourceID, userID, 'check-in')
             }
             resourceEntries.push(resourceEntry)
         }
@@ -466,10 +466,16 @@ class ProjectStore {
     }
 
     // remove remote resources from project file and manifest, update all windows 
-    removeLocalResource(resourceID, userID, resourceEntry, lastActionType) {
+    removeLocalResource(resourceID, userID, lastActionType) {
+        const resourceEntry = this.manifestData.resources[resourceID]
         this.projectArchiveWorker.postMessage({ messageType: 'remove-file', fileID: resourceID })
         resourceEntry.local = false
         resourceEntry.lastAction = { action_type: lastActionType, user: { id: userID } }
+        const childIds = Object.keys(this.manifestData.resources)
+            .filter(i => this.manifestData.resources[i].parentResource === resourceID)
+        for (const childId of childIds) {
+            this.removeLocalResource(childId, userID, lastActionType)
+        }
         this.fairCopyApplication.sendToAllWindows('resourceEntryUpdated', resourceEntry )
         delete this.manifestData.resources[resourceID]
     }

--- a/src/main-process/ProjectStore.js
+++ b/src/main-process/ProjectStore.js
@@ -422,7 +422,14 @@ class ProjectStore {
         const { userID } = this.manifestData
         const resourceEntry = this.manifestData.resources[resourceID]
         if( resourceEntry ) {
-            this.removeLocalResource(resourceID, userID, 'abandon_check_out')
+            const children = Object.values(this.manifestData.resources)
+                .filter( r => r.parentResource === resourceID )
+            for (const entry of [resourceEntry, ...children]) {
+                this.projectArchiveWorker.postMessage({ messageType: 'remove-file', fileID: entry.id })
+                this.fairCopyApplication.sendToAllWindows('resourceEntryUpdated', entry)
+                delete this.manifestData.resources[entry.id]
+            }
+            this.saveManifest()
         }
     }
 
@@ -452,7 +459,12 @@ class ProjectStore {
         for( const resourceID of Object.keys(resourceStatus) ) {
             const resourceEntry = this.manifestData.resources[resourceID]
             if( !error ) {
-                this.removeLocalResource(resourceID, userID, 'check-in')
+                // remove remote resources from project file and manifest, update all windows 
+                this.projectArchiveWorker.postMessage({ messageType: 'remove-file', fileID: resourceID })
+                resourceEntry.local = false
+                resourceEntry.lastAction = { action_type: 'check_in', user: { id: userID } }
+                this.fairCopyApplication.sendToAllWindows('resourceEntryUpdated', resourceEntry )
+                delete this.manifestData.resources[resourceID]
             }
             resourceEntries.push(resourceEntry)
         }
@@ -463,21 +475,6 @@ class ProjectStore {
             this.fairCopyApplication.fairCopySession.requestResourceView()
         }
         this.fairCopyApplication.sendToMainWindow('checkInResults', {resourceEntries, resourceStatus, error} ) 
-    }
-
-    // remove remote resources from project file and manifest, update all windows 
-    removeLocalResource(resourceID, userID, lastActionType) {
-        const resourceEntry = this.manifestData.resources[resourceID]
-        this.projectArchiveWorker.postMessage({ messageType: 'remove-file', fileID: resourceID })
-        resourceEntry.local = false
-        resourceEntry.lastAction = { action_type: lastActionType, user: { id: userID } }
-        const childIds = Object.keys(this.manifestData.resources)
-            .filter(i => this.manifestData.resources[i].parentResource === resourceID)
-        for (const childId of childIds) {
-            this.removeLocalResource(childId, userID, lastActionType)
-        }
-        this.fairCopyApplication.sendToAllWindows('resourceEntryUpdated', resourceEntry )
-        delete this.manifestData.resources[resourceID]
     }
 
     // send a list of the local resources to main window

--- a/src/main-process/RemoteProject.js
+++ b/src/main-process/RemoteProject.js
@@ -94,9 +94,6 @@ class RemoteProject {
                             if (remoteResource) {
                                 // mismatched action type, or action type is the same but user ID is different,
                                 // means this is probably an abandoned resource
-                                console.log('checking if resource is abandoned', { resource, remoteResource })
-                                console.log('last actions', { local: resource.lastAction, remote: remoteResource.lastAction })
-                                console.log('user', { local: resource.lastAction?.user, remote: remoteResource.lastAction?.user })
                                 return (
                                     resource.lastAction?.action_type !== remoteResource.lastAction?.action_type ||
                                     resource.lastAction?.user?.id !== remoteResource.lastAction?.user?.id

--- a/src/main-process/RemoteProject.js
+++ b/src/main-process/RemoteProject.js
@@ -94,6 +94,9 @@ class RemoteProject {
                             if (remoteResource) {
                                 // mismatched action type, or action type is the same but user ID is different,
                                 // means this is probably an abandoned resource
+                                console.log('checking if resource is abandoned', { resource, remoteResource })
+                                console.log('last actions', { local: resource.lastAction, remote: remoteResource.lastAction })
+                                console.log('user', { local: resource.lastAction?.user, remote: remoteResource.lastAction?.user })
                                 return (
                                     resource.lastAction?.action_type !== remoteResource.lastAction?.action_type ||
                                     resource.lastAction?.user?.id !== remoteResource.lastAction?.user?.id

--- a/src/render/components/common/PopupMenu.jsx
+++ b/src/render/components/common/PopupMenu.jsx
@@ -26,7 +26,8 @@ export default class PopupMenu extends Component {
         'export': 'fa-download',
         'move': 'fa-folder-open',
         'abandon': 'fa-lock-open',
-        'recover': 'fa-trash-arrow-up'
+        'recover': 'fa-trash-arrow-up',
+        'revert': 'fa-undo'
     }
 
     render() {

--- a/src/render/components/main-window/MainWindow.jsx
+++ b/src/render/components/main-window/MainWindow.jsx
@@ -976,17 +976,33 @@ export default class MainWindow extends Component {
         fairCopy.ipcSend('requestExport', resourceEntries)
         this.setState({ ...nextState, ...closePopUpState })
         break
-      case 'abandon':
-        const alertOptions = {
-          onAbandon: () => fairCopy.ipcSend('abandon', resourceEntries),
-          resource: resourceEntries[0],
+      case 'revert':
+        {
+          const alertOptions = {
+            onAbandon: () => fairCopy.ipcSend('abandon', resourceEntries),
+            resource: resourceEntries[0],
+          }
+          this.setState({
+            ...nextState,
+            alertDialogMode: 'confirmRevert',
+            alertOptions,
+            ...closePopUpState,
+          })
         }
-        this.setState({
-          ...nextState,
-          alertDialogMode: 'confirmAbandonCheckout',
-          alertOptions,
-          ...closePopUpState,
-        })
+        break
+      case 'abandon':
+        {
+          const alertOptions = {
+            onAbandon: () => fairCopy.ipcSend('abandon', resourceEntries),
+            resource: resourceEntries[0],
+          }
+          this.setState({
+            ...nextState,
+            alertDialogMode: 'confirmAbandonCheckout',
+            alertOptions,
+            ...closePopUpState,
+          })
+        }
         break
       default:
         console.error(`Unrecognized resource action id: ${actionID}`)

--- a/src/render/components/main-window/dialogs/AlertDialog.jsx
+++ b/src/render/components/main-window/dialogs/AlertDialog.jsx
@@ -175,7 +175,7 @@ export default class AlertDialog extends Component {
         return this.renderDialog( title, message, actions )
     }
 
-    renderConfirmAbandon() {
+    renderConfirmAbandon(verb) {
         const { alertOptions, onCloseAlert } = this.props
 
         const onAbandonCheckout = () => {
@@ -190,13 +190,14 @@ export default class AlertDialog extends Component {
 
         const { resource } = alertOptions
         const resourceName = resource.name
-        const title = "Confirm Unlock"
-        const message = `Unlocking "${resourceName}" will force a check-in,
-            abandoning all local work by the user who checked it out. This
-            action cannot be undone. Are you sure you want to proceed?`
+        const title = `Confirm ${verb}`
+        const message = `${verb}ing "${resourceName}" will abandon all local work
+            by the user who checked it out and return the resource
+            to the server. This action cannot be undone.
+            Are you sure you want to proceed?`
         const actions = [
             {
-                label: "Unlock",
+                label: verb,
                 defaultAction: true,
                 handler: onAbandonCheckout
             },
@@ -221,7 +222,9 @@ export default class AlertDialog extends Component {
             case 'confirmDeleteImages':
                 return this.renderConfirmDeleteImages()
             case 'confirmAbandonCheckout':
-                return this.renderConfirmAbandon()
+                return this.renderConfirmAbandon('Unlock')
+            case 'confirmRevert':
+                return this.renderConfirmAbandon('Revert')
             case 'closed':
             default:
                 return null

--- a/src/render/components/main-window/dialogs/AlertDialog.jsx
+++ b/src/render/components/main-window/dialogs/AlertDialog.jsx
@@ -191,10 +191,16 @@ export default class AlertDialog extends Component {
         const { resource } = alertOptions
         const resourceName = resource.name
         const title = `Confirm ${verb}`
-        const message = `${verb}ing "${resourceName}" will abandon all local work
-            by the user who checked it out and return the resource
-            to the server. This action cannot be undone.
-            Are you sure you want to proceed?`
+
+        let message
+        if ( verb === 'Revert' ) {
+            message = `Do you wish to revert the changes you have made since you checked out ${resourceName}?`
+        } else {
+            message = `Abandoning "${resourceName}" will abandon all local work
+                by the user who checked it out and return the resource
+                to the server. This action cannot be undone.`
+        }
+    
         const actions = [
             {
                 label: verb,

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -98,8 +98,12 @@ export default class ResourceBrowser extends Component {
       })
     }
 
-    // can also abandon checkout if the resource is checked out by the current user
-    const showRevert = canAbandonOwnResource(permissions, resource, userID) && atRemoteProjectRoot
+    // can revert (which is actually abandon checkout behind the scenes)
+    // if the resource is checked out by the current user and
+    // the resource is a top-level TEI document
+    const showRevert = canAbandonOwnResource(permissions, resource, userID)
+      && atRemoteProjectRoot
+      && !resource.parentResource
     if (showRevert) {
       menuOptions.push({
         id: 'revert',

--- a/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
+++ b/src/render/components/main-window/resource-browser/ResourceBrowser.jsx
@@ -6,7 +6,7 @@ import { debounce } from "debounce";
 
 import { getResourceIcon, getActionIcon, getResourceIconLabel } from '../../../model/resource-icon';
 import { isEntryEditable, isCheckedOutRemote } from '../../../model/FairCopyProject'
-import { canAbandon, canCheckOut, canCreate, canDelete, isAdmin } from '../../../model/permissions'
+import { canAbandonOtherUsersResources, canAbandonOwnResource, canCheckOut, canCreate, canDelete, isAdmin } from '../../../model/permissions'
 import { ellipsis } from '../../../model/ellipsis'
 
 const idealNameLength = 35
@@ -88,13 +88,24 @@ export default class ResourceBrowser extends Component {
     // if the resource is checked out by someone else, can abandon checkout
     const isAbandonable = resource?.lastAction?.action_type === 'check_out' &&
       resource.lastAction.user?.id !== userID
-    const showAbandon = canAbandon(permissions) && isAbandonable && atRemoteProjectRoot && currentView === 'remote'
+    const showAbandon = canAbandonOtherUsersResources(permissions) && isAbandonable && atRemoteProjectRoot && currentView === 'remote'
     if (showAbandon) {
       menuOptions.push({
         id: 'abandon',
         label: 'Unlock',
         classes: 'danger',
         action: this.createResourceAction('abandon', resource),
+      })
+    }
+
+    // can also abandon checkout if the resource is checked out by the current user
+    const showRevert = canAbandonOwnResource(permissions, resource, userID) && atRemoteProjectRoot
+    if (showRevert) {
+      menuOptions.push({
+        id: 'revert',
+        label: 'Revert',
+        classes: 'danger',
+        action: this.createResourceAction('revert', resource),
       })
     }
 

--- a/src/render/model/permissions.js
+++ b/src/render/model/permissions.js
@@ -25,7 +25,15 @@ export function canDelete(permissions) {
     return false
 }
 
-export function canAbandon(permissions) {
+export function canAbandonOtherUsersResources(permissions) {
     if (isAdmin(permissions)) return true
+    return false
+}
+
+export function canAbandonOwnResource(permissions, resource, userID) {
+    // allow the user to abandon if they have checkout permissions and they are the one who checked out the resource
+    if (canCheckOut(permissions) && resource?.lastAction?.action_type === 'check_out' && resource.lastAction.user?.id === userID) {
+        return true
+    }
     return false
 }


### PR DESCRIPTION
# Summary

This PR adds the ability to revert local changes. Behind the scenes, an `abandon_checkout` API request is sent to FairCopy Server and the local resource is deleted from the project.