### PR TITLE
Update default SSO URL

### DIFF
--- a/src/render/components/project-window/LoginPanel.jsx
+++ b/src/render/components/project-window/LoginPanel.jsx
@@ -13,7 +13,7 @@ export default class LoginPanel extends Component {
         super()
         this.initialState = { 
             // ...localHostDefaults,
-            ssoUrl: 'https://beta-app.faircopy.cloud/',
+            ssoUrl: 'https://faircopy.performant.studio',
             waiting: false,
             errorMessage: null
         }


### PR DESCRIPTION
# Summary

This PR updates the default SSO login URL to `faircopy.performant.studio`.